### PR TITLE
1. 因为实际需要添加了慢放和镜像的功能, 两个功能的开关可以在播放器管理单例中配置. BMPlayerConf.slowAndMirro…

### DIFF
--- a/BMPlayer/Classes/BMPlayer.swift
+++ b/BMPlayer/Classes/BMPlayer.swift
@@ -68,6 +68,8 @@ public class BMPlayer: UIView {
     private var isVolume        = false
     private var isMaskShowing   = false
     private var isFullScreen    = false
+    private var isSlowed = false
+    private var isMirrored    = false
     
     
     // MARK: - Public functions
@@ -161,6 +163,18 @@ public class BMPlayer: UIView {
      */
     public func cancelAutoFadeOutControlBar() {
         NSObject.cancelPreviousPerformRequestsWithTarget(self)
+    }
+    
+    /**
+     旋转屏幕时更新UI
+     */
+    public func updateUI(isFullScreen: Bool) {
+        if isFullScreen {
+            controlView.isFullScreen = true
+        }else {
+            controlView.isFullScreen = false
+        }
+        controlView.updateUI()
     }
     
     /**
@@ -332,6 +346,29 @@ public class BMPlayer: UIView {
         }
     }
     
+    @objc private func slowButtonPressed(button: UIButton) {
+        if isSlowed {
+            self.playerLayer?.player?.rate = 1.0
+            self.isSlowed = false
+            self.controlView.slowButton.setTitle("慢放", forState: .Normal)
+        } else {
+            self.playerLayer?.player?.rate = 0.5
+            self.isSlowed = true
+            self.controlView.slowButton.setTitle("正常", forState: .Normal)
+        }
+    }
+    
+    @objc private func mirrorButtonPressed(button: UIButton) {
+        if isMirrored {
+            self.playerLayer?.transform = CGAffineTransformMakeScale(1.0, 1.0)
+            self.isMirrored = false
+            self.controlView.mirrorButton.setTitle("镜像", forState: .Normal)
+        } else {
+            self.playerLayer?.transform = CGAffineTransformMakeScale(-1.0, 1.0)
+            self.isMirrored = true
+            self.controlView.slowButton.setTitle("正常", forState: .Normal)
+        }    }
+    
     @objc private func replayButtonPressed(button: UIButton) {
         controlView.centerButton.hidden = true
         playerLayer?.seekToTime(0, completionHandler: {
@@ -420,6 +457,8 @@ public class BMPlayer: UIView {
         controlView.timeSlider.addTarget(self, action: #selector(progressSliderTouchBegan(_:)), forControlEvents: UIControlEvents.TouchDown)
         controlView.timeSlider.addTarget(self, action: #selector(progressSliderValueChanged(_:)), forControlEvents: UIControlEvents.ValueChanged)
         controlView.timeSlider.addTarget(self, action: #selector(progressSliderTouchEnded(_:)), forControlEvents: [UIControlEvents.TouchUpInside,UIControlEvents.TouchCancel, UIControlEvents.TouchUpOutside])
+        controlView.slowButton.addTarget(self, action: #selector(slowButtonPressed(_:)), forControlEvents: .TouchUpInside)
+        controlView.mirrorButton.addTarget(self, action: #selector(mirrorButtonPressed(_:)), forControlEvents: .TouchUpInside)
     }
     
     private func configureVolume() {

--- a/BMPlayer/Classes/BMPlayerControlView.swift
+++ b/BMPlayer/Classes/BMPlayerControlView.swift
@@ -34,6 +34,10 @@ class BMPlayerControlView: UIView {
     var progressView     = UIProgressView()
     var playButton       = UIButton(type: UIButtonType.Custom)
     var fullScreenButton = UIButton(type: UIButtonType.Custom)
+    var slowButton = UIButton(type: UIButtonType.Custom)
+    var mirrorButton = UIButton(type: UIButtonType.Custom)
+    
+    
     
     /// 中间部分
     var loadingIndector  = NVActivityIndicatorView(frame:  CGRect(x: 0, y: 0, width: 30, height: 30))
@@ -81,6 +85,18 @@ class BMPlayerControlView: UIView {
     
     func updateUI() {
         if isFullScreen {
+            if BMPlayerConf.slowAndMirror {
+                self.slowButton.hidden = false
+                self.mirrorButton.hidden = false
+
+                fullScreenButton.snp_remakeConstraints { (make) in
+                    make.width.equalTo(50)
+                    make.height.equalTo(50)
+                    make.centerY.equalTo(currentTimeLabel)
+                    make.left.equalTo(slowButton.snp_right)
+                    make.right.equalTo(bottomMaskView.snp_right)
+                }
+            }
             chooseDefitionView.hidden = false
             if BMPlayerConf.topBarShowInCase.rawValue == 2 {
                 topMaskView.hidden = true
@@ -94,6 +110,16 @@ class BMPlayerControlView: UIView {
                 topMaskView.hidden = false
             }
             chooseDefitionView.hidden = true
+            
+            self.slowButton.hidden = true
+            self.mirrorButton.hidden = true
+            fullScreenButton.snp_remakeConstraints { (make) in
+                make.width.equalTo(50)
+                make.height.equalTo(50)
+                make.centerY.equalTo(currentTimeLabel)
+                make.left.equalTo(totalTimeLabel.snp_right)
+                make.right.equalTo(bottomMaskView.snp_right)
+            }
         }
     }
     
@@ -229,6 +255,8 @@ class BMPlayerControlView: UIView {
         bottomMaskView.addSubview(progressView)
         bottomMaskView.addSubview(timeSlider)
         bottomMaskView.addSubview(fullScreenButton)
+        bottomMaskView.addSubview(mirrorButton)
+        bottomMaskView.addSubview(slowButton)
         
         playButton.setImage(BMImageResourcePath("BMPlayer_play"), forState: UIControlState.Normal)
         playButton.setImage(BMImageResourcePath("BMPlayer_pause"), forState: UIControlState.Selected)
@@ -255,6 +283,20 @@ class BMPlayerControlView: UIView {
         progressView.trackTintColor = UIColor ( red: 1.0, green: 1.0, blue: 1.0, alpha: 0.3 )
         
         fullScreenButton.setImage(BMImageResourcePath("BMPlayer_fullscreen"), forState: UIControlState.Normal)
+        
+        mirrorButton.layer.borderWidth = 1
+        mirrorButton.layer.borderColor = UIColor(red: 204.0 / 255.0, green: 204.0 / 255.0, blue: 204.0 / 255.0, alpha: 1.0).CGColor
+        mirrorButton.layer.cornerRadius = 2.0
+        mirrorButton.setTitle("镜像", forState: UIControlState.Normal)
+        mirrorButton.titleLabel?.font = UIFont.systemFontOfSize(14)
+        mirrorButton.hidden = true
+        
+        slowButton.layer.borderWidth = 1
+        slowButton.layer.borderColor = UIColor(red: 204.0 / 255.0, green: 204.0 / 255.0, blue: 204.0 / 255.0, alpha: 1.0).CGColor
+        slowButton.layer.cornerRadius = 2.0
+        slowButton.setTitle("慢放", forState: UIControlState.Normal)
+        slowButton.titleLabel?.font = UIFont.systemFontOfSize(14)
+        mirrorButton.hidden = true
         
         // 中间
         mainMaskView.addSubview(loadingIndector)
@@ -351,6 +393,20 @@ class BMPlayerControlView: UIView {
             make.centerY.equalTo(currentTimeLabel)
             make.left.equalTo(timeSlider.snp_right).offset(5)
             make.width.equalTo(40)
+        }
+        
+        mirrorButton.snp_makeConstraints { (make) in
+            make.width.equalTo(50)
+            make.height.equalTo(30)
+            make.left.equalTo(totalTimeLabel.snp_right).offset(10)
+            make.centerY.equalTo(currentTimeLabel)
+        }
+        
+        slowButton.snp_makeConstraints { (make) in
+            make.width.equalTo(50)
+            make.height.equalTo(30)
+            make.left.equalTo(mirrorButton.snp_right).offset(10)
+            make.centerY.equalTo(currentTimeLabel)
         }
         
         fullScreenButton.snp_makeConstraints { (make) in

--- a/BMPlayer/Classes/BMPlayerManager.swift
+++ b/BMPlayer/Classes/BMPlayerManager.swift
@@ -32,6 +32,9 @@ public class BMPlayerManager {
     
     public var topBarShowInCase = BMPlayerTopBarShowCase.Always
     
+    /// 是否显示慢放和镜像按钮
+    public var slowAndMirror = false
+    
     /// 是否打印log
     public var allowLog  = false
     /**

--- a/Example/BMPlayer/VideoPlayViewController.swift
+++ b/Example/BMPlayer/VideoPlayViewController.swift
@@ -14,7 +14,7 @@ class VideoPlayViewController: UIViewController {
     
     //    @IBOutlet weak var player: BMPlayer!
     
-    var player: BMPlayer!
+    var player: BMPlayer = BMPlayer()
     
     var index: NSIndexPath!
     
@@ -30,7 +30,6 @@ class VideoPlayViewController: UIViewController {
      准备playerView
      */
     func preparePlayer() {
-        player = BMPlayer()
         view.addSubview(player)
         player.snp_makeConstraints { (make) in
             make.top.equalTo(view.snp_top)
@@ -44,6 +43,24 @@ class VideoPlayViewController: UIViewController {
         }
         self.view.layoutIfNeeded()
     }
+    
+    override func willTransitionToTraitCollection(newCollection: UITraitCollection, withTransitionCoordinator coordinator: UIViewControllerTransitionCoordinator) {
+        super.willTransitionToTraitCollection(newCollection, withTransitionCoordinator: coordinator)
+        coordinator.animateAlongsideTransition({
+            a in
+            
+            if (newCollection.verticalSizeClass == UIUserInterfaceSizeClass.Compact) {
+                self.player.updateUI(true)
+            } else {
+                self.player.updateUI(false)
+                //To Do: modify something for other vertical size
+            }
+            self.view.setNeedsLayout()
+            }, completion: nil)
+        
+        
+    }
+    
     
     // 设置播放资源
     func setupPlayerResource() {
@@ -66,6 +83,7 @@ class VideoPlayViewController: UIViewController {
     // 设置播放器单例，修改属性
     func setupPlayerManager() {
         resetPlayerManager()
+        BMPlayerConf.slowAndMirror = true
         switch (index.section,index.row) {
         // 普通播放器
         case (0,0):


### PR DESCRIPTION
1. 因为实际需要添加了慢放和镜像的功能, 两个功能的开关可以在播放器管理单例中配置. BMPlayerConf.slowAndMirror = true

2. 在BMPlayer类中添加了一个方法updateUI(Bool), 用于解决手动旋转设备横屏时不能调用到ControlView中的updateUI方法,导致切换清晰度按钮不能更新的问题. 具体的调用方法为在播放Controller中override willTransitionToTraitCollection方法.

``` swift
override func willTransitionToTraitCollection(newCollection: UITraitCollection, withTransitionCoordinator coordinator: UIViewControllerTransitionCoordinator) {
        super.willTransitionToTraitCollection(newCollection, withTransitionCoordinator: coordinator)
        coordinator.animateAlongsideTransition({
            a in
            
            if (newCollection.verticalSizeClass == UIUserInterfaceSizeClass.Compact) {
                self.player.updateUI(true)
            } else {
                self.player.updateUI(false)
                //To Do: modify something for other vertical size
            }
            self.view.setNeedsLayout()
            }, completion: nil)
        
        
    }
    
```