### PR TITLE
FIX：播放器的URL从服务器有可能获取失败导致播放器的URL为空，此时手动点击播放按钮会导致崩溃

### DIFF
--- a/BMPlayer/Classes/BMPlayerLayerView.swift
+++ b/BMPlayer/Classes/BMPlayerLayerView.swift
@@ -22,7 +22,11 @@ open class BMPlayerLayerView: UIView {
     
     /// 视频URL
     open var videoURL: URL! {
-        didSet { onSetVideoURL() }
+        didSet {
+            if videoURL != nil {
+                onSetVideoURL()
+            }
+        }
     }
     
     /// 视频跳转秒数置0


### PR DESCRIPTION
提升下播放器的容错，视频URL从服务器获取有可能失败导致URL为NIL，虽然可以判断不调用`player.playWithURL`
但是播放器已经初始化，手动点击播放器的播放按钮会导致崩溃

更好的解决方法是不是应该把
`open var videoURL: URL! `
改成
`open var videoURL: URL？`
然后在内部做相关的判断？