### PR TITLE
Hide replay button when pressed

### DIFF
--- a/BMPlayer/Classes/BMPlayer.swift
+++ b/BMPlayer/Classes/BMPlayer.swift
@@ -462,6 +462,7 @@ open class BMPlayer: UIView {
         playerLayer?.seekToTime(0, completionHandler: {
             
         })
+        controlView.playerReplayButton?.isHidden = true
         self.play()
     }
     


### PR DESCRIPTION
Hide replay button when it is pressed.  Currently the button remains visible after being pressed.