### PR TITLE
Notification of Player State Changes

### DIFF
--- a/BMPlayer/Classes/BMPlayer.swift
+++ b/BMPlayer/Classes/BMPlayer.swift
@@ -117,6 +117,12 @@ open class BMPlayer: UIView {
     //视频画面比例
     fileprivate var aspectRatio:BMPlayerAspectRatio = .default
     
+    //Cache is playing result to improve callback performance
+    fileprivate var isPlayingCache: Bool? = nil
+    //Closure fired when play time changed
+    open var playTimeDidChange:((TimeInterval, TimeInterval) -> Void)?
+    //Closure fired when play state chaged
+    open var playStateDidChange:((Bool) -> Void)?
     
     // MARK: - Public functions
     /**
@@ -613,6 +619,12 @@ extension BMPlayer: BMPlayerLayerViewDelegate {
     public func bmPlayer(player: BMPlayerLayerView, playerIsPlaying playing: Bool) {
         playStateDidChanged()
         delegate?.bmPlayer(player: self, playerIsPlaying: playing)
+        if isPlayingCache != playing && playStateDidChange != nil {
+            isPlayingCache = playing
+            DispatchQueue.global(qos: .utility).async {
+                self.playStateDidChange!(playing)
+            }
+        }
     }
     
     public func bmPlayer(player: BMPlayerLayerView ,loadedTimeDidChange  loadedDuration: TimeInterval , totalDuration: TimeInterval) {
@@ -666,6 +678,12 @@ extension BMPlayer: BMPlayerLayerViewDelegate {
         controlView.playerTotalTimeLabel?.text = formatSecondsToString(totalTime)
         
         controlView.playerTimeSlider?.value    = Float(currentTime) / Float(totalTime)
+        
+        if playTimeDidChange != nil {
+            DispatchQueue.global(qos: .utility).async {
+                self.playTimeDidChange!(currentTime, totalTime)
+            }
+        }
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,20 @@ let item = BMPlayerItem(title: "周末号外丨川普版权力的游戏",
                         cover: "http://img.wdjimg.com/image/video/acdba01e52efe8082d7c33556cf61549_0_0.jpeg")
 ```
 
+### Listening to player state changes
+```swift
+
+//Listen to when the player is playing or stopped
+player?.playStateDidChange = { (isPlaying: Bool) in
+    print("playStateDidChange \(isPlaying)")
+}
+
+//Listen to when the play time changes
+player?.playTimeDidChange = { (currentTime: TimeInterval, totalTime: TimeInterval) in
+    print("playTimeDidChange currentTime: \(currentTime) totalTime: \(totalTime)")
+}
+```
+
 ## Customize player
 Needs to change before the player alloc.
 


### PR DESCRIPTION
Add closures to listen to state changes in the player.

This allows the developer to listen to the basic events of start, stop, and play time changed.

```swift
        player?.playStateDidChange = { (isPlaying: Bool) in
            print("playStateDidChange \(isPlaying)")
        }

        player?.playTimeDidChange = { (currentTime: TimeInterval, totalTime: TimeInterval) in
            print("playTimeDidChange currentTime: \(currentTime) totalTime: \(totalTime)")
        }
```