### PR TITLE
Add PlayerStateChanged callback

### DIFF
--- a/BMPlayer/Classes/BMPlayer.swift
+++ b/BMPlayer/Classes/BMPlayer.swift
@@ -119,10 +119,14 @@ open class BMPlayer: UIView {
     
     //Cache is playing result to improve callback performance
     fileprivate var isPlayingCache: Bool? = nil
+    //Cache last player state result to improve callback performance
+    var playerStateCache: BMPlayerState? = nil
     //Closure fired when play time changed
     open var playTimeDidChange:((TimeInterval, TimeInterval) -> Void)?
-    //Closure fired when play state chaged
+    //Closure fired when play state changed
     open var playStateDidChange:((Bool) -> Void)?
+    //Closure fired when player state changed
+    open var playerStateDidChange:((BMPlayerState) -> Void)?
     
     // MARK: - Public functions
     /**
@@ -663,6 +667,13 @@ extension BMPlayer: BMPlayerLayerViewDelegate {
             controlView.showPlayToTheEndView()
         default:
             break
+        }
+        
+        if playerStateDidChange != nil && playerStateCache != state {
+            playerStateCache = state
+            DispatchQueue.global(qos: .utility).async {
+                self.playerStateDidChange!(state)
+            }
         }
     }
     

--- a/README.md
+++ b/README.md
@@ -119,12 +119,17 @@ let item = BMPlayerItem(title: "周末号外丨川普版权力的游戏",
 
 //Listen to when the player is playing or stopped
 player?.playStateDidChange = { (isPlaying: Bool) in
-    print("playStateDidChange \(isPlaying)")
+    print("playStateDidChange: \(isPlaying)")
 }
 
 //Listen to when the play time changes
 player?.playTimeDidChange = { (currentTime: TimeInterval, totalTime: TimeInterval) in
     print("playTimeDidChange currentTime: \(currentTime) totalTime: \(totalTime)")
+}
+
+//Listen to when the player state changes
+player?.playerStateDidChange = {(state: BMPlayerState) in
+    print("player state changed to: \(state)")
 }
 ```
 


### PR DESCRIPTION
Thank you for creating a great player.  For a project I need the calling layer or controller to be able to listen to specific player state changed events.  Similarly to the player is playing event I've created a PR which calls a closure, i.e. callback style.

~~~
        player?.playerStateDidChange = {(state: BMPlayerState) in
            print("player state changed to: \(state)")
        }
~~~

Thank you for all of your help and building a great player.