### PR TITLE
修复 cover url 下载失败导致 carsh

### DIFF
--- a/BMPlayer/Classes/BMPlayerControlView.swift
+++ b/BMPlayer/Classes/BMPlayerControlView.swift
@@ -191,7 +191,11 @@ class BMPlayerControlView: UIView, BMPlayerCustomControlView {
             DispatchQueue.global(qos: .default).async {
                 let data = try? Data(contentsOf: url) //make sure your image in this url does exist, otherwise unwrap in a if let check
                 DispatchQueue.main.async(execute: {
-                    self.maskImageView.image = UIImage(data: data!)
+                    if let data = data {
+                        self.maskImageView.image = UIImage(data: data)
+                    } else {
+                        self.maskImageView.image = nil
+                    }
                     self.hideLoader()
                 });
             }


### PR DESCRIPTION
比如 cover url 为`http://localhost:8080/pic/05620C4576C5AABD65EE85D0FEF750CF_md5_201611051533414156-750_750.jpg` 时，会 carsh