### PR TITLE
On replay fire playerIsPlaying delegate

### DIFF
--- a/BMPlayer/Classes/BMPlayer.swift
+++ b/BMPlayer/Classes/BMPlayer.swift
@@ -480,6 +480,8 @@ open class BMPlayer: UIView {
             
         })
         controlView.playerReplayButton?.isHidden = true
+        isPlayToTheEnd = false
+        playerLayer?.isPlaying = true
         self.play()
     }
     


### PR DESCRIPTION
Hello,
When I press the replay button it doesn't trigger the bmPlayer(player: BMPlayer, playerIsPlaying playing: Bool) delegate method.

I added a reset on two flags to the replayButtonPressed method to fix this.