### PR TITLE
fix  "player.panGesture.isEnable = false" invalid bug

### DIFF
--- a/Example/BMPlayer.xcodeproj/project.pbxproj
+++ b/Example/BMPlayer.xcodeproj/project.pbxproj
@@ -211,12 +211,13 @@
 				TargetAttributes = {
 					607FACCF1AFB9204008FA782 = {
 						CreatedOnToolsVersion = 6.3.1;
-						DevelopmentTeam = SMPQ9YA3H4;
+						DevelopmentTeam = SXRTDM2GE2;
 						LastSwiftMigration = 0800;
+						ProvisioningStyle = Automatic;
 					};
 					6AAA77071CE18427009745BA = {
 						CreatedOnToolsVersion = 7.3.1;
-						DevelopmentTeam = SMPQ9YA3H4;
+						DevelopmentTeam = SXRTDM2GE2;
 						LastSwiftMigration = 0800;
 					};
 				};
@@ -448,12 +449,15 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				DEVELOPMENT_TEAM = SXRTDM2GE2;
 				INFOPLIST_FILE = BMPlayer/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = org.cocoapods.demo.BMPlayer;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
@@ -465,12 +469,15 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				DEVELOPMENT_TEAM = SXRTDM2GE2;
 				INFOPLIST_FILE = BMPlayer/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = org.cocoapods.demo.BMPlayer;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
@@ -480,7 +487,7 @@
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
-				DEVELOPMENT_TEAM = SMPQ9YA3H4;
+				DEVELOPMENT_TEAM = SXRTDM2GE2;
 				INFOPLIST_FILE = BMPlayer_Tests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -494,7 +501,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
-				DEVELOPMENT_TEAM = SMPQ9YA3H4;
+				DEVELOPMENT_TEAM = SXRTDM2GE2;
 				INFOPLIST_FILE = BMPlayer_Tests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";

--- a/Source/BMPlayer.swift
+++ b/Source/BMPlayer.swift
@@ -104,7 +104,7 @@ open class BMPlayer: UIView {
     fileprivate var isPlayToTheEnd  = false
     //视频画面比例
     fileprivate var aspectRatio:BMPlayerAspectRatio = .default
-    
+      
     //Cache is playing result to improve callback performance
     fileprivate var isPlayingCache: Bool? = nil
     
@@ -156,7 +156,6 @@ open class BMPlayer: UIView {
             isURLSet                = true
         }
         
-        panGesture.isEnabled = true
         playerLayer?.play()
         isPauseByUser = false
     }
@@ -226,6 +225,10 @@ open class BMPlayer: UIView {
     // MARK: - Action Response
     
     @objc fileprivate func panDirection(_ pan: UIPanGestureRecognizer) {
+        // 播放结束时，忽略手势
+        guard playerLayer?.state != .playedToTheEnd else {
+            return
+        }
         // 根据在view上Pan的位置，确定是调音量还是亮度
         let locationPoint = pan.location(in: self)
         
@@ -462,7 +465,7 @@ extension BMPlayer: BMPlayerLayerViewDelegate {
         default:
             break
         }
-        panGesture.isEnabled = state != .playedToTheEnd
+
         delegate?.bmPlayer(player: self, playerStateDidChange: state)
     }
     

--- a/Source/BMPlayerLayerView.swift
+++ b/Source/BMPlayerLayerView.swift
@@ -104,7 +104,7 @@ open class BMPlayerLayerView: UIView {
     /// 音量滑杆
     fileprivate var volumeViewSlider: UISlider!
     /// 播发器的几种状态
-    fileprivate var state = BMPlayerState.notSetURL {
+    internal fileprivate(set) var state = BMPlayerState.notSetURL {
         didSet {
             if state != oldValue {
                 delegate?.bmPlayer(player: self, playerStateDidChange: state)


### PR DESCRIPTION
BMPlayer中有panGesture属性，
我遇到的需求是需要禁用 控制调节亮度和音量的这个手势。
在原来的代码中，如果我这样设置

`player.panGesture.isEnable = false`

无效，手势依然存在。
于是我调整了一下代码，修复了这个问题。