### PR TITLE
fix bug of control view dismissing when played to the end

### DIFF
--- a/Source/BMPlayerControlView.swift
+++ b/Source/BMPlayerControlView.swift
@@ -155,7 +155,6 @@ open class BMPlayerControlView: UIView {
             playButton.isSelected = false
             showPlayToTheEndView()
             controlViewAnimation(isShow: true)
-            cancelAutoFadeOutAnimation()
             
         default:
             break
@@ -208,7 +207,9 @@ open class BMPlayerControlView: UIView {
     open func autoFadeOutControlViewWithAnimation() {
         cancelAutoFadeOutAnimation()
         delayItem = DispatchWorkItem { [weak self] in
-            self?.controlViewAnimation(isShow: false)
+            if self?.playerLastState != .playedToTheEnd {
+                self?.controlViewAnimation(isShow: false)
+            }
         }
         DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + BMPlayerConf.animateDelayTimeInterval,
                                       execute: delayItem!)

--- a/Source/BMPlayerLayerView.swift
+++ b/Source/BMPlayerLayerView.swift
@@ -103,7 +103,7 @@ open class BMPlayerLayerView: UIView {
     fileprivate var playerLayer: AVPlayerLayer?
     /// 音量滑杆
     fileprivate var volumeViewSlider: UISlider!
-    /// 播发器的几种状态
+    /// 播放器的几种状态
     fileprivate var state = BMPlayerState.notSetURL {
         didSet {
             if state != oldValue {

--- a/Source/CacheSupport/BMPlayerManager.swift
+++ b/Source/CacheSupport/BMPlayerManager.swift
@@ -44,6 +44,7 @@ open class BMPlayerManager {
     open var enableBrightnessGestures = true
     open var enableVolumeGestures = true
     open var enablePlaytimeGestures = true
+    open var enableChooseDefinition = true
 
     open var cacheManeger = VIResourceLoaderManager()
     


### PR DESCRIPTION
发现一个bug，视频播放完后control view会自动dismiss，并且手势失效，control view不会再出现

我在delayItem的callback中加了对播放状态的判断，因为我觉得这里的逻辑就应该是如果播放停止，则不dismiss control view。

然后我还发现```BMPlayerControlView.swift``` 中的 ```open weak var player: BMPlayer? ```是没用到的
```BMPlayer.swift```中的
```
    fileprivate let BMPlayerAnimationTimeInterval:Double                = 4.0
    fileprivate let BMPlayerControlBarAutoFadeOutTimeInterval:Double    = 0.5
```
也是没有用的，感觉可以删掉。

非常感谢开源这个项目，对我的项目有很大的帮助，望采纳