### PR TITLE
Remove usage of SnapKit dependency, add BMError enum type, fix compilation error in example project and fix UI in example project

### DIFF
--- a/BMError.swift
+++ b/BMError.swift
@@ -1,0 +1,13 @@
+//
+//  BMError.swift
+//  BMPlayer
+//
+//  Created by Paul Wallace on 4/24/18.
+//
+
+
+import Foundation
+
+public enum BMError : String {
+    case version = "This pod only support iOS 9 and greater."
+}

--- a/Example/BMPlayer.xcodeproj/project.pbxproj
+++ b/Example/BMPlayer.xcodeproj/project.pbxproj
@@ -216,7 +216,7 @@
 				TargetAttributes = {
 					607FACCF1AFB9204008FA782 = {
 						CreatedOnToolsVersion = 6.3.1;
-						DevelopmentTeam = SMPQ9YA3H4;
+						DevelopmentTeam = SDK5NG227W;
 						LastSwiftMigration = 0800;
 						ProvisioningStyle = Automatic;
 					};
@@ -484,9 +484,9 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				DEVELOPMENT_TEAM = SMPQ9YA3H4;
+				DEVELOPMENT_TEAM = SDK5NG227W;
 				INFOPLIST_FILE = BMPlayer/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = org.cocoapods.demo.BMPlayer;
@@ -504,9 +504,9 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				DEVELOPMENT_TEAM = SMPQ9YA3H4;
+				DEVELOPMENT_TEAM = SDK5NG227W;
 				INFOPLIST_FILE = BMPlayer/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = org.cocoapods.demo.BMPlayer;

--- a/Example/BMPlayer.xcodeproj/project.pbxproj
+++ b/Example/BMPlayer.xcodeproj/project.pbxproj
@@ -216,7 +216,7 @@
 				TargetAttributes = {
 					607FACCF1AFB9204008FA782 = {
 						CreatedOnToolsVersion = 6.3.1;
-						DevelopmentTeam = SDK5NG227W;
+						DevelopmentTeam = SMPQ9YA3H4;
 						LastSwiftMigration = 0800;
 						ProvisioningStyle = Automatic;
 					};
@@ -484,9 +484,9 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				DEVELOPMENT_TEAM = SDK5NG227W;
+				DEVELOPMENT_TEAM = SMPQ9YA3H4;
 				INFOPLIST_FILE = BMPlayer/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = org.cocoapods.demo.BMPlayer;
@@ -504,9 +504,9 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				DEVELOPMENT_TEAM = SDK5NG227W;
+				DEVELOPMENT_TEAM = SMPQ9YA3H4;
 				INFOPLIST_FILE = BMPlayer/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = org.cocoapods.demo.BMPlayer;

--- a/Example/BMPlayer/BMCustomPlayer.swift
+++ b/Example/BMPlayer/BMCustomPlayer.swift
@@ -10,7 +10,7 @@ import UIKit
 import BMPlayer
 
 class BMCustomPlayer: BMPlayer {
-    class override func storyBoardCustomControl() -> BMPlayerControlView? {
+    override func storyBoardCustomControl() -> BMPlayerControlView? {
         return BMPlayerCustomControlView()
     }
 }

--- a/Example/BMPlayer/BMPlayerCustomControlView.swift
+++ b/Example/BMPlayer/BMPlayerCustomControlView.swift
@@ -67,9 +67,9 @@ class BMPlayerCustomControlView: BMPlayerControlView {
         }
     }
     
+    //Leave status bar handling to the application
     override func controlViewAnimation(isShow: Bool) {
         self.isMaskShowing = isShow
-        UIApplication.shared.setStatusBarHidden(!isShow, with: .fade)
         
         UIView.animate(withDuration: 0.24, animations: {
             self.topMaskView.snp.remakeConstraints {

--- a/Example/BMPlayer/Base.lproj/Main.storyboard
+++ b/Example/BMPlayer/Base.lproj/Main.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES" initialViewController="udg-xo-r4F">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES" initialViewController="udg-xo-r4F">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13527"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
         <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -53,7 +53,7 @@
                             <constraint firstItem="hDp-Hj-Ti4" firstAttribute="leading" secondItem="kh9-bI-dsS" secondAttribute="leading" id="2X8-z8-Pkw"/>
                             <constraint firstItem="hDp-Hj-Ti4" firstAttribute="top" secondItem="kh9-bI-dsS" secondAttribute="top" id="6B6-TO-z4D"/>
                             <constraint firstItem="xba-Qr-GbE" firstAttribute="top" secondItem="hDp-Hj-Ti4" secondAttribute="bottom" id="DVT-e2-oB8"/>
-                            <constraint firstItem="xba-Qr-GbE" firstAttribute="top" secondItem="kh9-bI-dsS" secondAttribute="top" constant="64" id="La8-WM-lPa"/>
+                            <constraint firstItem="xba-Qr-GbE" firstAttribute="top" secondItem="jyV-Pf-zRb" secondAttribute="bottom" id="La8-WM-lPa"/>
                             <constraint firstItem="2fi-mo-0CV" firstAttribute="top" secondItem="xba-Qr-GbE" secondAttribute="bottom" id="Tjl-x1-lUm"/>
                             <constraint firstAttribute="trailing" secondItem="xba-Qr-GbE" secondAttribute="trailing" id="myg-f6-BFa"/>
                             <constraint firstItem="xba-Qr-GbE" firstAttribute="leading" secondItem="kh9-bI-dsS" secondAttribute="leading" id="z0s-N9-U12"/>

--- a/Example/BMPlayer/VideoPlayViewController.swift
+++ b/Example/BMPlayer/VideoPlayViewController.swift
@@ -29,7 +29,7 @@ class VideoPlayViewController: UIViewController {
   
   var changeButton = UIButton()
     
-    var playerTopConstraint: NSLayoutConstraint!
+  var playerTopConstraint: NSLayoutConstraint!
     
   override func viewDidLoad() {
     super.viewDidLoad()
@@ -288,7 +288,6 @@ extension VideoPlayViewController: BMPlayerDelegate {
             if #available(iOS 11.0, *) {
                 playerTopConstraint = player.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor)
             } else {
-                // Fallback on earlier versions
                 playerTopConstraint = player.topAnchor.constraint(equalTo: view.topAnchor)
             }
            playerTopConstraint.isActive = true

--- a/Example/BMPlayer/VideoPlayViewController.swift
+++ b/Example/BMPlayer/VideoPlayViewController.swift
@@ -28,7 +28,9 @@ class VideoPlayViewController: UIViewController {
   var index: IndexPath!
   
   var changeButton = UIButton()
-  
+    
+    var playerTopConstraint: NSLayoutConstraint!
+    
   override func viewDidLoad() {
     super.viewDidLoad()
     setupPlayerManager()
@@ -69,13 +71,23 @@ class VideoPlayViewController: UIViewController {
     }
     
     player = BMPlayer(customControlView: controller)
+    player.translatesAutoresizingMaskIntoConstraints = false
     view.addSubview(player)
-    
-    player.snp.makeConstraints { (make) in
-      make.top.equalTo(view.snp.top)
-      make.left.equalTo(view.snp.left)
-      make.right.equalTo(view.snp.right)
-      make.height.equalTo(view.snp.width).multipliedBy(9.0/16.0).priority(500)
+    if #available(iOS 11.0, *) {
+        player.heightAnchor.constraint(equalTo: view.safeAreaLayoutGuide.widthAnchor, multiplier: 9/16).isActive = true
+        playerTopConstraint = player.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor)
+        playerTopConstraint.isActive = true
+        player.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor).isActive = true
+        player.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor).isActive = true
+    } else {
+        if #available(iOS 9.0, *) {
+            player.bottomAnchor.constraint(equalTo: view.bottomAnchor).isActive = true
+            player.topAnchor.constraint(equalTo: view.topAnchor).isActive = true
+            player.leadingAnchor.constraint(equalTo: view.leadingAnchor).isActive = true
+            player.trailingAnchor.constraint(equalTo: view.trailingAnchor).isActive = true
+        } else {
+            print("This pod does not support below iOS 9.0")
+        }
     }
     
     player.delegate = self
@@ -91,33 +103,21 @@ class VideoPlayViewController: UIViewController {
     changeButton.addTarget(self, action: #selector(onChangeVideoButtonPressed), for: .touchUpInside)
     changeButton.backgroundColor = UIColor.red.withAlphaComponent(0.7)
     view.addSubview(changeButton)
-    
-    changeButton.snp.makeConstraints { (make) in
-      make.top.equalTo(player.snp.bottom).offset(30)
-      make.left.equalTo(view.snp.left).offset(10)
+    changeButton.translatesAutoresizingMaskIntoConstraints = false
+    if #available(iOS 9.0, *) {
+        changeButton.topAnchor.constraint(equalTo: player.bottomAnchor, constant: 30).isActive = true
+        changeButton.leadingAnchor.constraint(equalTo: player.leadingAnchor, constant: 10).isActive = true
+    } else {
+        print("This pod does not support below iOS 9")
     }
     changeButton.isHidden = true
     self.view.layoutIfNeeded()
   }
   
-  
   @objc fileprivate func onChangeVideoButtonPressed() {
-    let urls = ["http://wvideo.spriteapp.cn/video/2016/0328/56f8ec01d9bfe_wpd.mp4",
-                "http://baobab.wdjcdn.com/1456117847747a_x264.mp4",
-                "http://baobab.wdjcdn.com/14525705791193.mp4",
-                "http://baobab.wdjcdn.com/1456459181808howtoloseweight_x264.mp4",
-                "http://baobab.wdjcdn.com/1455968234865481297704.mp4",
-                "http://baobab.wdjcdn.com/1455782903700jy.mp4",
-                "http://baobab.wdjcdn.com/14564977406580.mp4",
-                "http://baobab.wdjcdn.com/1456316686552The.mp4",
-                "http://baobab.wdjcdn.com/1456480115661mtl.mp4",
-                "http://baobab.wdjcdn.com/1456665467509qingshu.mp4",
-                "http://baobab.wdjcdn.com/1455614108256t(2).mp4",
-                "http://baobab.wdjcdn.com/1456317490140jiyiyuetai_x264.mp4",
-                "http://baobab.wdjcdn.com/1455888619273255747085_x264.mp4",
-                "http://baobab.wdjcdn.com/1456734464766B(13).mp4",
-                "http://baobab.wdjcdn.com/1456653443902B.mp4",
-                "http://baobab.wdjcdn.com/1456231710844S(24).mp4"]
+    let urls = ["http://us-west-1-cdn.indi.com/Zencoder/z3_0/a88dbdd7d5236918df5c5d358d676b38/video-0480p-1088k.mp4",
+                "http://us-west-1-cdn.indi.com/Zencoder/z3_0/a88dbdd7d5236918df5c5d358d676b38/video-0480p-1088k.mp4",
+                "http://us-west-1-cdn.indi.com/Zencoder/z3_0/a88dbdd7d5236918df5c5d358d676b38/video-0480p-1088k.mp4"]
     let random = Int(arc4random_uniform(UInt32(urls.count)))
     let asset = BMPlayerResource(url: URL(string: urls[random])!, name: "Video @\(random)")
     player.setVideo(resource: asset)
@@ -129,7 +129,7 @@ class VideoPlayViewController: UIViewController {
       
     case (0,0):
       let str = Bundle.main.url(forResource: "SubtitleDemo", withExtension: "srt")!
-      let url = URL(string: "http://baobab.wdjcdn.com/1456117847747a_x264.mp4")!
+      let url = URL(string: "http://us-west-1-cdn.indi.com/Zencoder/z3_0/a88dbdd7d5236918df5c5d358d676b38/video-0480p-1088k.mp4")!
       
       let subtitle = BMSubtitles(url: str)
       
@@ -278,15 +278,23 @@ class VideoPlayViewController: UIViewController {
 extension VideoPlayViewController: BMPlayerDelegate {
   // Call when player orinet changed
   func bmPlayer(player: BMPlayer, playerOrientChanged isFullscreen: Bool) {
-    player.snp.remakeConstraints { (make) in
-      make.top.equalTo(view.snp.top)
-      make.left.equalTo(view.snp.left)
-      make.right.equalTo(view.snp.right)
-      if isFullscreen {
-        make.bottom.equalTo(view.snp.bottom)
-      } else {
-        make.height.equalTo(view.snp.width).multipliedBy(9.0/16.0).priority(500)
-      }
+    navigationController?.setNavigationBarHidden(isFullscreen, animated: true)
+    playerTopConstraint.isActive = false
+    if #available(iOS 9.0, *) {
+        if isFullscreen {
+            playerTopConstraint = player.topAnchor.constraint(equalTo: view.topAnchor)
+            playerTopConstraint.isActive = true
+        } else {
+            if #available(iOS 11.0, *) {
+                playerTopConstraint = player.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor)
+            } else {
+                // Fallback on earlier versions
+                playerTopConstraint = player.topAnchor.constraint(equalTo: view.topAnchor)
+            }
+           playerTopConstraint.isActive = true
+        }
+    } else {
+        print("Not allowed in < iOS 9.0")
     }
   }
   

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -65,6 +65,7 @@
 		86B7A9566C11893527BE8149461AE757 /* NVActivityIndicatorAnimationBallRotate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D4B696348AC5FE5EE5D36F7FE5DF584 /* NVActivityIndicatorAnimationBallRotate.swift */; };
 		8723C3F66EDEF07021C509111ED7F0E4 /* NVActivityIndicatorViewable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BB696EAA4F192F17506935BC732E094 /* NVActivityIndicatorViewable.swift */; };
 		877B11A66B2C7AC867F86D5507B777EF /* NVActivityIndicatorAnimationBlank.swift in Sources */ = {isa = PBXBuildFile; fileRef = E03D3AD7002EEEEEB475128C1D241989 /* NVActivityIndicatorAnimationBlank.swift */; };
+		8981248D20913F2500F0A9A5 /* BMError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8981248C20913F2400F0A9A5 /* BMError.swift */; };
 		8BB73B1C8EAD7D7185EAC3730C61E644 /* NVActivityIndicatorAnimationLineScale.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5E062D352AAE623C860AAB977B7CE67 /* NVActivityIndicatorAnimationLineScale.swift */; };
 		8C8C708118BB1FE9182CD8375A8EAA6B /* NVActivityIndicatorAnimationBallGridPulse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3463ABD75DFB4EB77B5CFC76FE4BB0A5 /* NVActivityIndicatorAnimationBallGridPulse.swift */; };
 		91C917245BE34395D3C764FF0EE8B536 /* VIResourceLoaderManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 16BA8E22F2B1F14E3A1062448E1E012E /* VIResourceLoaderManager.m */; };
@@ -208,11 +209,11 @@
 		00D1F9DFF39B7F710729F95DC6130A63 /* VICacheSessionManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = VICacheSessionManager.h; path = VIMediaCache/Cache/VICacheSessionManager.h; sourceTree = "<group>"; };
 		03363B6FDCFD4214868A5D1FC4A390CA /* VIMediaCache-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "VIMediaCache-dummy.m"; sourceTree = "<group>"; };
 		0682BEECE81E3882AF3CB2BCBBC29F80 /* BMPlayerControlView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BMPlayerControlView.swift; path = Source/BMPlayerControlView.swift; sourceTree = "<group>"; };
-		07E58095A8196AAC6782B7848A5C78A4 /* VIMediaCache.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; path = VIMediaCache.modulemap; sourceTree = "<group>"; };
+		07E58095A8196AAC6782B7848A5C78A4 /* VIMediaCache.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = VIMediaCache.modulemap; sourceTree = "<group>"; };
 		0824361B921ECEBF8C54167DEDC61660 /* ConstraintMakerFinalizable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ConstraintMakerFinalizable.swift; path = Source/ConstraintMakerFinalizable.swift; sourceTree = "<group>"; };
 		08620D5D03A8F110592B3633EAA7EF9E /* VIMediaCache.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = VIMediaCache.xcconfig; sourceTree = "<group>"; };
 		0B1F00AE16DC2FA64CA820DBD69C373D /* NVActivityIndicatorAnimationLineScalePulseOutRapid.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NVActivityIndicatorAnimationLineScalePulseOutRapid.swift; path = NVActivityIndicatorView/NVActivityIndicatorView/Animations/NVActivityIndicatorAnimationLineScalePulseOutRapid.swift; sourceTree = "<group>"; };
-		0B3510D7EED62FD9F36F83F4E7A2E88F /* BMPlayer.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = BMPlayer.framework; path = BMPlayer.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		0B3510D7EED62FD9F36F83F4E7A2E88F /* BMPlayer.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BMPlayer.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		0B39076E7A24F0F601B676057D846F60 /* NVActivityIndicatorView-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "NVActivityIndicatorView-dummy.m"; sourceTree = "<group>"; };
 		0BE3CC03E06322FE6049EB34EE71932A /* NVActivityIndicatorAnimationBallZigZag.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NVActivityIndicatorAnimationBallZigZag.swift; path = NVActivityIndicatorView/NVActivityIndicatorView/Animations/NVActivityIndicatorAnimationBallZigZag.swift; sourceTree = "<group>"; };
 		0C17B637E28276C0B6996C4550E72F10 /* LayoutConstraint.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LayoutConstraint.swift; path = Source/LayoutConstraint.swift; sourceTree = "<group>"; };
@@ -223,19 +224,19 @@
 		1590982EA8B02AA9BE70BF800E6E7FCA /* ConstraintMakerPriortizable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ConstraintMakerPriortizable.swift; path = Source/ConstraintMakerPriortizable.swift; sourceTree = "<group>"; };
 		16BA8E22F2B1F14E3A1062448E1E012E /* VIResourceLoaderManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = VIResourceLoaderManager.m; path = VIMediaCache/ResourceLoader/VIResourceLoaderManager.m; sourceTree = "<group>"; };
 		17716048F8A280FEFE9A6726964138E9 /* ConstraintRelatableTarget.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ConstraintRelatableTarget.swift; path = Source/ConstraintRelatableTarget.swift; sourceTree = "<group>"; };
-		1945D3C85874665943E8193615F97182 /* VIMediaCache.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = VIMediaCache.framework; path = VIMediaCache.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		1945D3C85874665943E8193615F97182 /* VIMediaCache.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = VIMediaCache.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1BD40932369F0CE39BC2E0CF0DD98868 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		1CB25A1F22A1604A652B0CFF0ADC23A2 /* BMSubtitles.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BMSubtitles.swift; path = Source/BMSubtitles.swift; sourceTree = "<group>"; };
 		1D4B696348AC5FE5EE5D36F7FE5DF584 /* NVActivityIndicatorAnimationBallRotate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NVActivityIndicatorAnimationBallRotate.swift; path = NVActivityIndicatorView/NVActivityIndicatorView/Animations/NVActivityIndicatorAnimationBallRotate.swift; sourceTree = "<group>"; };
-		1DD68B9A7394F16E1FF6A9DE0356971A /* Pods_BMPlayer_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_BMPlayer_Example.framework; path = "Pods-BMPlayer_Example.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		1DD68B9A7394F16E1FF6A9DE0356971A /* Pods_BMPlayer_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BMPlayer_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		251CCB4F4FD00AE4B09A6F555974F932 /* Pods-BMPlayer_Example-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-BMPlayer_Example-umbrella.h"; sourceTree = "<group>"; };
 		2525FE3CCE4586806B20086FA68A4069 /* LayoutConstraintItem.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LayoutConstraintItem.swift; path = Source/LayoutConstraintItem.swift; sourceTree = "<group>"; };
 		279741231DFC3507029926EBB4FC768F /* NVActivityIndicatorAnimationBallBeat.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NVActivityIndicatorAnimationBallBeat.swift; path = NVActivityIndicatorView/NVActivityIndicatorView/Animations/NVActivityIndicatorAnimationBallBeat.swift; sourceTree = "<group>"; };
-		2913E77B21693C7EB83355FBDBC26330 /* SwipeBack.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; path = SwipeBack.modulemap; sourceTree = "<group>"; };
+		2913E77B21693C7EB83355FBDBC26330 /* SwipeBack.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = SwipeBack.modulemap; sourceTree = "<group>"; };
 		2BEE8FFCEDD6FFBE723B7114C545ACB0 /* NVActivityIndicatorAnimationBallScaleRipple.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NVActivityIndicatorAnimationBallScaleRipple.swift; path = NVActivityIndicatorView/NVActivityIndicatorView/Animations/NVActivityIndicatorAnimationBallScaleRipple.swift; sourceTree = "<group>"; };
 		2F941A3EA5EB370F0DA3994DB2DD95C1 /* VIResourceLoadingRequestWorker.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = VIResourceLoadingRequestWorker.h; path = VIMediaCache/ResourceLoader/VIResourceLoadingRequestWorker.h; sourceTree = "<group>"; };
 		31D87377FED2D4FA4CEF3062419F7CC9 /* VICacheManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = VICacheManager.h; path = VIMediaCache/Cache/VICacheManager.h; sourceTree = "<group>"; };
-		329858A4956C565282F3F8918D6027EE /* SnapKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = SnapKit.framework; path = SnapKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		329858A4956C565282F3F8918D6027EE /* SnapKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SnapKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		338A0BA253CD6528BE77CB282B249524 /* ConstraintInsets.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ConstraintInsets.swift; path = Source/ConstraintInsets.swift; sourceTree = "<group>"; };
 		3463ABD75DFB4EB77B5CFC76FE4BB0A5 /* NVActivityIndicatorAnimationBallGridPulse.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NVActivityIndicatorAnimationBallGridPulse.swift; path = NVActivityIndicatorView/NVActivityIndicatorView/Animations/NVActivityIndicatorAnimationBallGridPulse.swift; sourceTree = "<group>"; };
 		354F56186734BDE81A77D8D99CAAD50B /* NVActivityIndicatorAnimationBallSpinFadeLoader.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NVActivityIndicatorAnimationBallSpinFadeLoader.swift; path = NVActivityIndicatorView/NVActivityIndicatorView/Animations/NVActivityIndicatorAnimationBallSpinFadeLoader.swift; sourceTree = "<group>"; };
@@ -248,13 +249,13 @@
 		3FA147579C65E983F954394B3C423C54 /* UINavigationController+SwipeBack.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UINavigationController+SwipeBack.m"; path = "SwipeBack/UINavigationController+SwipeBack.m"; sourceTree = "<group>"; };
 		3FB8AEAFF9B1DBF071B3A33E183CC542 /* SnapKit-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "SnapKit-dummy.m"; sourceTree = "<group>"; };
 		40CCB975D5E9E8843D31E43CACB199F3 /* NVActivityIndicatorAnimationBallScale.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NVActivityIndicatorAnimationBallScale.swift; path = NVActivityIndicatorView/NVActivityIndicatorView/Animations/NVActivityIndicatorAnimationBallScale.swift; sourceTree = "<group>"; };
-		47A0061BAAC43212319CD61E5E5B7F2D /* SnapKit.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; path = SnapKit.modulemap; sourceTree = "<group>"; };
+		47A0061BAAC43212319CD61E5E5B7F2D /* SnapKit.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = SnapKit.modulemap; sourceTree = "<group>"; };
 		48FA3A274519194A1A57F64C33240D67 /* VICacheAction.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = VICacheAction.h; path = VIMediaCache/Cache/VICacheAction.h; sourceTree = "<group>"; };
 		490A4D797EA7ABF5BB304C099F36E825 /* NVActivityIndicatorAnimationBallTrianglePath.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NVActivityIndicatorAnimationBallTrianglePath.swift; path = NVActivityIndicatorView/NVActivityIndicatorView/Animations/NVActivityIndicatorAnimationBallTrianglePath.swift; sourceTree = "<group>"; };
 		4A519C0B8DD1DD528BFB59F0F496152E /* SwipeBack-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "SwipeBack-prefix.pch"; sourceTree = "<group>"; };
 		4AA294A109A17405195DBBFAEEE0FDE1 /* NVActivityIndicatorAnimationBallZigZagDeflect.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NVActivityIndicatorAnimationBallZigZagDeflect.swift; path = NVActivityIndicatorView/NVActivityIndicatorView/Animations/NVActivityIndicatorAnimationBallZigZagDeflect.swift; sourceTree = "<group>"; };
 		4BB696EAA4F192F17506935BC732E094 /* NVActivityIndicatorViewable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NVActivityIndicatorViewable.swift; path = NVActivityIndicatorView/NVActivityIndicatorView/Presenter/NVActivityIndicatorViewable.swift; sourceTree = "<group>"; };
-		4E27723E7B6EB0291752282156C53E0D /* BMPlayer.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; path = BMPlayer.modulemap; sourceTree = "<group>"; };
+		4E27723E7B6EB0291752282156C53E0D /* BMPlayer.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = BMPlayer.modulemap; sourceTree = "<group>"; };
 		4FBBB448715BD56EFDF11B9D69975CCD /* NVActivityIndicatorPresenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NVActivityIndicatorPresenter.swift; path = NVActivityIndicatorView/NVActivityIndicatorView/Presenter/NVActivityIndicatorPresenter.swift; sourceTree = "<group>"; };
 		5348FF656605F7D02FEE6EF7F10EE063 /* ConstraintInsetTarget.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ConstraintInsetTarget.swift; path = Source/ConstraintInsetTarget.swift; sourceTree = "<group>"; };
 		538007643A79D730F84E0FB766F13A78 /* VIMediaCache-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "VIMediaCache-prefix.pch"; sourceTree = "<group>"; };
@@ -270,14 +271,14 @@
 		61B1FEB80828FED50E854081D8F4A42E /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS10.3.sdk/System/Library/Frameworks/QuartzCore.framework; sourceTree = DEVELOPER_DIR; };
 		621DB56D01D5F869D9FDED4F164509FA /* NVActivityIndicatorAnimationSquareSpin.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NVActivityIndicatorAnimationSquareSpin.swift; path = NVActivityIndicatorView/NVActivityIndicatorView/Animations/NVActivityIndicatorAnimationSquareSpin.swift; sourceTree = "<group>"; };
 		650FFFE7F4EA86EC5055B20888D313BC /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		654D92521DEE92E381AD5559FAFBD391 /* NVActivityIndicatorView.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; path = NVActivityIndicatorView.modulemap; sourceTree = "<group>"; };
+		654D92521DEE92E381AD5559FAFBD391 /* NVActivityIndicatorView.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = NVActivityIndicatorView.modulemap; sourceTree = "<group>"; };
 		66486740FD27E84BA5119DED0CC82D42 /* SwipeBack.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SwipeBack.h; path = SwipeBack/SwipeBack.h; sourceTree = "<group>"; };
 		6819B15C7C06D53348CFAC48DB4A423E /* UIViewController+SwipeBack.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIViewController+SwipeBack.m"; path = "SwipeBack/UIViewController+SwipeBack.m"; sourceTree = "<group>"; };
 		682513D3D963C5A006B97391A38468FE /* NVActivityIndicatorAnimationBallClipRotatePulse.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NVActivityIndicatorAnimationBallClipRotatePulse.swift; path = NVActivityIndicatorView/NVActivityIndicatorView/Animations/NVActivityIndicatorAnimationBallClipRotatePulse.swift; sourceTree = "<group>"; };
 		6A0E7EF30F7C081D6BEA92EE25B22F97 /* BMPlayerLayerView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BMPlayerLayerView.swift; path = Source/BMPlayerLayerView.swift; sourceTree = "<group>"; };
 		6EEBF8FCB2DE378E199D5140762FFA96 /* Constraint.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Constraint.swift; path = Source/Constraint.swift; sourceTree = "<group>"; };
 		70FBDFFC78EEE1EEF89D058FCF352BF4 /* ConstraintView+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "ConstraintView+Extensions.swift"; path = "Source/ConstraintView+Extensions.swift"; sourceTree = "<group>"; };
-		732412A17B81E4D9BB94C2E5759726C5 /* SwipeBack.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = SwipeBack.framework; path = SwipeBack.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		732412A17B81E4D9BB94C2E5759726C5 /* SwipeBack.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwipeBack.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		74CBC89BFB92A2050ED5042D46074328 /* VIMediaCache.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = VIMediaCache.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7891AC4BB5C13114E3A7A7ACAFEF1758 /* SnapKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SnapKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		792C23DD55939E35B980E41BE55E4D02 /* VIMediaCacheWorker.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = VIMediaCacheWorker.h; path = VIMediaCache/Cache/VIMediaCacheWorker.h; sourceTree = "<group>"; };
@@ -291,11 +292,12 @@
 		857002F7B986610F3EFCAB4FE2A62D93 /* SwipeBack.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = SwipeBack.xcconfig; sourceTree = "<group>"; };
 		85B2F615A1B80F15269489BCF2D14C93 /* ConstraintDescription.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ConstraintDescription.swift; path = Source/ConstraintDescription.swift; sourceTree = "<group>"; };
 		8639375AEFFE223C10590FD171222DFB /* VIMediaCache-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "VIMediaCache-umbrella.h"; sourceTree = "<group>"; };
+		8981248C20913F2400F0A9A5 /* BMError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BMError.swift; sourceTree = "<group>"; };
 		89CECDE07849EFAEAD6E47D7490E8C84 /* NVActivityIndicatorAnimationTriangleSkewSpin.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NVActivityIndicatorAnimationTriangleSkewSpin.swift; path = NVActivityIndicatorView/NVActivityIndicatorView/Animations/NVActivityIndicatorAnimationTriangleSkewSpin.swift; sourceTree = "<group>"; };
 		8DA3B09055A2D76E25C66FC6D39281D6 /* NVActivityIndicatorView.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = NVActivityIndicatorView.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8EBA14458D77031ED9DD9DF89C2CA708 /* NVActivityIndicatorAnimationPacman.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NVActivityIndicatorAnimationPacman.swift; path = NVActivityIndicatorView/NVActivityIndicatorView/Animations/NVActivityIndicatorAnimationPacman.swift; sourceTree = "<group>"; };
 		8EFACF06F3BCEFFB08EC9E99A02B2303 /* BMPlayer.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = BMPlayer.xcconfig; sourceTree = "<group>"; };
-		93A4A3777CF96A4AAC1D13BA6DCCEA73 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		93A4A3777CF96A4AAC1D13BA6DCCEA73 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		978F0A86C2906419C2374A7FBA0E2BF0 /* NVActivityIndicatorAnimationBallPulse.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NVActivityIndicatorAnimationBallPulse.swift; path = NVActivityIndicatorView/NVActivityIndicatorView/Animations/NVActivityIndicatorAnimationBallPulse.swift; sourceTree = "<group>"; };
 		9814E36EDBB18F161B7662E67B9D25B8 /* VIMediaDownloader.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = VIMediaDownloader.h; path = VIMediaCache/ResourceLoader/VIMediaDownloader.h; sourceTree = "<group>"; };
 		99232A303A892CB10EC6725CF42751B3 /* VIMediaDownloader.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = VIMediaDownloader.m; path = VIMediaCache/ResourceLoader/VIMediaDownloader.m; sourceTree = "<group>"; };
@@ -355,7 +357,7 @@
 		E9496677AC3F73BFE080120C84BE27A3 /* ConstraintConstantTarget.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ConstraintConstantTarget.swift; path = Source/ConstraintConstantTarget.swift; sourceTree = "<group>"; };
 		ECDB4C2E193F0A6AA6E8F578A40DCA82 /* ConstraintLayoutGuide+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "ConstraintLayoutGuide+Extensions.swift"; path = "Source/ConstraintLayoutGuide+Extensions.swift"; sourceTree = "<group>"; };
 		ED24264F3820DE09A88EBCDFDC0952AB /* VICacheManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = VICacheManager.m; path = VIMediaCache/Cache/VICacheManager.m; sourceTree = "<group>"; };
-		EDE1DEAF007E48C73BA470D8AFAE2446 /* Pods-BMPlayer_Example.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; path = "Pods-BMPlayer_Example.modulemap"; sourceTree = "<group>"; };
+		EDE1DEAF007E48C73BA470D8AFAE2446 /* Pods-BMPlayer_Example.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = "Pods-BMPlayer_Example.modulemap"; sourceTree = "<group>"; };
 		EF99A1E66B9482B394C5ED43D423EF01 /* NVActivityIndicatorAnimationCubeTransition.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NVActivityIndicatorAnimationCubeTransition.swift; path = NVActivityIndicatorView/NVActivityIndicatorView/Animations/NVActivityIndicatorAnimationCubeTransition.swift; sourceTree = "<group>"; };
 		F1A34774A688579092F0D7B8AEE82A91 /* SwipeBack-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "SwipeBack-umbrella.h"; sourceTree = "<group>"; };
 		F1FF129E806B9B104E3665DEC1A9F2DE /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -363,7 +365,7 @@
 		F53F2F9322CBA6B467D0FD454E915765 /* NVActivityIndicatorView.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = NVActivityIndicatorView.xcconfig; sourceTree = "<group>"; };
 		F6D49A2486A061622928187EAAFA1DFC /* VIMediaCache.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = VIMediaCache.h; path = VIMediaCache/VIMediaCache.h; sourceTree = "<group>"; };
 		FCB9665A10EEBB40E498FDB05F99D5E4 /* SnapKit-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "SnapKit-prefix.pch"; sourceTree = "<group>"; };
-		FCE1BAEBCEE8C3079032FFF7FF0038A5 /* NVActivityIndicatorView.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = NVActivityIndicatorView.framework; path = NVActivityIndicatorView.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		FCE1BAEBCEE8C3079032FFF7FF0038A5 /* NVActivityIndicatorView.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = NVActivityIndicatorView.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FDED71A8A650FD70D9FAED6662A9496B /* NVActivityIndicatorAnimationBallScaleRippleMultiple.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NVActivityIndicatorAnimationBallScaleRippleMultiple.swift; path = NVActivityIndicatorView/NVActivityIndicatorView/Animations/NVActivityIndicatorAnimationBallScaleRippleMultiple.swift; sourceTree = "<group>"; };
 		FE4A9788BFEBF3A5FE65B46F74C0EE1D /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS10.3.sdk/System/Library/Frameworks/AVFoundation.framework; sourceTree = DEVELOPER_DIR; };
 		FE98FDC76BCC3E5DF48BEF26DA5091BA /* ConstraintMultiplierTarget.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ConstraintMultiplierTarget.swift; path = Source/ConstraintMultiplierTarget.swift; sourceTree = "<group>"; };
@@ -548,7 +550,6 @@
 				DD93AAB0AF31424EF14F6B8D4B85E2DD /* Presenter */,
 				D9CC0FF0ADF1D1161F2F96A7B99D62C5 /* Support Files */,
 			);
-			name = NVActivityIndicatorView;
 			path = NVActivityIndicatorView;
 			sourceTree = "<group>";
 		};
@@ -590,7 +591,6 @@
 			children = (
 				7F7A0D660976D2927D89FB14524EDB3A /* Frameworks */,
 			);
-			name = "Reveal-SDK";
 			path = "Reveal-SDK";
 			sourceTree = "<group>";
 		};
@@ -689,13 +689,13 @@
 				A991D35920AF57C04B0F12D84948BEE1 /* UILayoutSupport+Extensions.swift */,
 				9D9032709BD0023D81823E3F63984810 /* Support Files */,
 			);
-			name = SnapKit;
 			path = SnapKit;
 			sourceTree = "<group>";
 		};
 		DAC3CFBCCF20AAE55EDFDC300873BFE7 /* CacheSupport */ = {
 			isa = PBXGroup;
 			children = (
+				8981248C20913F2400F0A9A5 /* BMError.swift */,
 				00917C862C83EB0303B89AE0B01B9D00 /* BMPlayer.swift */,
 				A03E374B876D9B66267F3B11496D3C11 /* BMPlayerClearityChooseButton.swift */,
 				0682BEECE81E3882AF3CB2BCBBC29F80 /* BMPlayerControlView.swift */,
@@ -780,7 +780,6 @@
 				0F279E4F7759EF4BD8311487D38A4445 /* VIResourceLoadingRequestWorker.m */,
 				730D8F36A2FE2847CB56E9324500BEAD /* Support Files */,
 			);
-			name = VIMediaCache;
 			path = VIMediaCache;
 			sourceTree = "<group>";
 		};
@@ -801,7 +800,6 @@
 				6819B15C7C06D53348CFAC48DB4A423E /* UIViewController+SwipeBack.m */,
 				1515E82C14A3067E760C806CA993057A /* Support Files */,
 			);
-			name = SwipeBack;
 			path = SwipeBack;
 			sourceTree = "<group>";
 		};
@@ -1135,6 +1133,7 @@
 				33D287518BE7E9F89A2D2ECC10B89482 /* BMPlayerManager.swift in Sources */,
 				9D14BF68EB97F7A237DEF2EE507BFDD6 /* BMPlayerProtocols.swift in Sources */,
 				9781943CF8B2A0F9EB6C9DBE4F4F9F1A /* BMSubtitles.swift in Sources */,
+				8981248D20913F2500F0A9A5 /* BMError.swift in Sources */,
 				8422928B984595E017375BBDC6EA8157 /* BMTimeSlider.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Source/BMPlayer.swift
+++ b/Source/BMPlayer.swift
@@ -327,15 +327,14 @@ open class BMPlayer: UIView {
         delegate?.bmPlayer(player: self, playerOrientChanged: isFullScreen)
     }
     
+    //Now let application handle the hiding and showing on the status bar
     @objc fileprivate func fullScreenButtonPressed() {
         controlView.updateUI(!self.isFullScreen)
         if isFullScreen {
             UIDevice.current.setValue(UIInterfaceOrientation.portrait.rawValue, forKey: "orientation")
-            UIApplication.shared.setStatusBarHidden(false, with: .fade)
             UIApplication.shared.statusBarOrientation = .portrait
         } else {
             UIDevice.current.setValue(UIInterfaceOrientation.landscapeRight.rawValue, forKey: "orientation")
-            UIApplication.shared.setStatusBarHidden(false, with: .fade)
             UIApplication.shared.statusBarOrientation = .landscapeRight
         }
     }

--- a/Source/BMPlayer.swift
+++ b/Source/BMPlayer.swift
@@ -391,10 +391,14 @@ open class BMPlayer: UIView {
         controlView.updateUI(isFullScreen)
         controlView.delegate = self
         controlView.player   = self
-        controlView.snp.makeConstraints { (make) in
-            make.edges.equalTo(self)
+        controlView.translatesAutoresizingMaskIntoConstraints = false
+        if #available(iOS 9.0, *) {
+            controlView.leadingAnchor.constraint(equalTo: self.leadingAnchor).isActive = true
+            controlView.trailingAnchor.constraint(equalTo: self.trailingAnchor).isActive = true
+            controlView.topAnchor.constraint(equalTo: self.topAnchor).isActive = true
+            controlView.bottomAnchor.constraint(equalTo: self.bottomAnchor).isActive = true
         }
-        
+
         panGesture = UIPanGestureRecognizer(target: self, action: #selector(self.panDirection(_:)))
         self.addGestureRecognizer(panGesture)
     }
@@ -416,8 +420,12 @@ open class BMPlayer: UIView {
         playerLayer = BMPlayerLayerView()
         playerLayer!.videoGravity = videoGravity
         insertSubview(playerLayer!, at: 0)
-        playerLayer!.snp.makeConstraints { (make) in
-            make.edges.equalTo(self)
+        playerLayer?.translatesAutoresizingMaskIntoConstraints = false
+        if #available(iOS 9.0, *) {
+            playerLayer?.leadingAnchor.constraint(equalTo: self.leadingAnchor).isActive = true
+            playerLayer?.trailingAnchor.constraint(equalTo: self.trailingAnchor).isActive = true
+            playerLayer?.topAnchor.constraint(equalTo: self.topAnchor).isActive = true
+            playerLayer?.bottomAnchor.constraint(equalTo: self.bottomAnchor).isActive = true
         }
         playerLayer!.delegate = self
         controlView.showLoader()

--- a/Source/BMPlayerControlView.swift
+++ b/Source/BMPlayerControlView.swift
@@ -225,20 +225,16 @@ open class BMPlayerControlView: UIView {
     
     /**
      Implement of the control view animation, override if need's custom animation
-     
+     This function no longer handles status bar hiding/showing.
      - parameter isShow: is to show the controlview
      */
     open func controlViewAnimation(isShow: Bool) {
         let alpha: CGFloat = isShow ? 1.0 : 0.0
         self.isMaskShowing = isShow
-        
-        UIApplication.shared.setStatusBarHidden(!isShow, with: .fade)
-        
         UIView.animate(withDuration: 0.3, animations: {
             self.topMaskView.alpha    = alpha
             self.bottomMaskView.alpha = alpha
             self.mainMaskView.backgroundColor = UIColor ( red: 0.0, green: 0.0, blue: 0.0, alpha: isShow ? 0.4 : 0.0)
-            
             if isShow {
                 if self.isFullscreen { self.chooseDefitionView.alpha = 1.0 }
             } else {
@@ -247,6 +243,8 @@ open class BMPlayerControlView: UIView {
                     self.chooseDefinitionHeightConstraint.isActive = false
                     self.chooseDefinitionHeightConstraint = self.chooseDefitionView.heightAnchor.constraint(equalToConstant: 35)
                     self.chooseDefinitionHeightConstraint.isActive = true
+                } else {
+                    fatalError(BMError.version.rawValue)
                 }
                 self.chooseDefitionView.alpha = 0.0
             }
@@ -351,13 +349,15 @@ open class BMPlayerControlView: UIView {
             
             button.setTitle("\(resource.definitions[button.tag].definition)", for: UIControlState())
             chooseDefitionView.addSubview(button)
-            button.addTarget(self, action: #selector(self.onDefinitionSelected(_:)), for: UIControlEvents.touchUpInside)
             if #available(iOS 9.0, *) {
+                button.addTarget(self, action: #selector(self.onDefinitionSelected(_:)), for: UIControlEvents.touchUpInside)
                 button.translatesAutoresizingMaskIntoConstraints = false
                 button.topAnchor.constraint(equalTo: chooseDefitionView.topAnchor, constant: CGFloat(35 * i)).isActive = true
                 button.widthAnchor.constraint(equalToConstant: 50).isActive = true
                 button.heightAnchor.constraint(equalToConstant: 25).isActive = true
                 button.centerXAnchor.constraint(equalTo: chooseDefitionView.centerXAnchor).isActive = true
+            } else {
+                fatalError(BMError.version.rawValue)
             }
             if resource.definitions.count == 1 {
                 button.isEnabled = false
@@ -435,13 +435,12 @@ open class BMPlayerControlView: UIView {
         }
     }
     
+    @available(iOS 9.0, *)
     @objc fileprivate func onDefinitionSelected(_ button:UIButton) {
         let height = isSelectecDefitionViewOpened ? 35 : resource!.definitions.count * 40
-        if #available(iOS 9.0, *) {
-            chooseDefinitionHeightConstraint.isActive = false
-            chooseDefinitionHeightConstraint = chooseDefitionView.heightAnchor.constraint(equalToConstant: CGFloat(height))
-            chooseDefinitionHeightConstraint.isActive = true
-        }
+        chooseDefinitionHeightConstraint.isActive = false
+        chooseDefinitionHeightConstraint = chooseDefitionView.heightAnchor.constraint(equalToConstant: CGFloat(height))
+        chooseDefinitionHeightConstraint.isActive = true
         
         UIView.animate(withDuration: 0.3, animations: {
             self.layoutIfNeeded()
@@ -462,14 +461,22 @@ open class BMPlayerControlView: UIView {
     override public init(frame: CGRect) {
         super.init(frame: frame)
         setupUIComponents()
-        addSnapKitConstraint()
+        if #available(iOS 9.0, *) {
+            addConstraints()
+        } else {
+            fatalError(BMError.version.rawValue)
+        }
         customizeUIComponents()
     }
     
     required public init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
         setupUIComponents()
-        addSnapKitConstraint()
+        if #available(iOS 9.0, *) {
+            addConstraints()
+        } else {
+            fatalError(BMError.version.rawValue)
+        }
         customizeUIComponents()
     }
     
@@ -595,147 +602,127 @@ open class BMPlayerControlView: UIView {
         addGestureRecognizer(tapGesture)
     }
     
-    func addSnapKitConstraint() {
+    @available(iOS 9.0, *)
+    func addConstraints() {
         // Main mask view
-        if #available(iOS 9.0, *) {
-            mainMaskView.translatesAutoresizingMaskIntoConstraints = false
-            mainMaskView.topAnchor.constraint(equalTo: self.topAnchor).isActive = true
-            mainMaskView.bottomAnchor.constraint(equalTo: self.bottomAnchor).isActive = true
-            mainMaskView.leadingAnchor.constraint(equalTo: self.leadingAnchor).isActive = true
-            mainMaskView.trailingAnchor.constraint(equalTo: self.trailingAnchor).isActive = true
-        }
-        if #available(iOS 9.0, *) {
-            maskImageView.translatesAutoresizingMaskIntoConstraints = false
-            mainMaskView.topAnchor.constraint(equalTo: mainMaskView.topAnchor).isActive = true
-            mainMaskView.bottomAnchor.constraint(equalTo: mainMaskView.bottomAnchor).isActive = true
-            mainMaskView.leadingAnchor.constraint(equalTo: mainMaskView.leadingAnchor).isActive = true
-            mainMaskView.trailingAnchor.constraint(equalTo: mainMaskView.trailingAnchor).isActive = true
-        }
-        if #available(iOS 9.0, *) {
-            topMaskView.translatesAutoresizingMaskIntoConstraints = false
-            topMaskView.topAnchor.constraint(equalTo: mainMaskView.topAnchor).isActive = true
-            topMaskView.leadingAnchor.constraint(equalTo: mainMaskView.leadingAnchor).isActive = true
-            topMaskView.trailingAnchor.constraint(equalTo: mainMaskView.trailingAnchor).isActive = true
-            topMaskView.heightAnchor.constraint(equalToConstant: 65).isActive = true
-        }
-        if #available(iOS 9.0, *) {
-            bottomMaskView.translatesAutoresizingMaskIntoConstraints = false
-            bottomMaskView.bottomAnchor.constraint(equalTo: mainMaskView.bottomAnchor).isActive = true
-            bottomMaskView.leadingAnchor.constraint(equalTo: mainMaskView.leadingAnchor).isActive = true
-            bottomMaskView.trailingAnchor.constraint(equalTo: mainMaskView.trailingAnchor).isActive = true
-            bottomMaskView.heightAnchor.constraint(equalToConstant: 50).isActive = true
-        }
+        mainMaskView.translatesAutoresizingMaskIntoConstraints = false
+        mainMaskView.topAnchor.constraint(equalTo: self.topAnchor).isActive = true
+        mainMaskView.bottomAnchor.constraint(equalTo: self.bottomAnchor).isActive = true
+        mainMaskView.leadingAnchor.constraint(equalTo: self.leadingAnchor).isActive = true
+        mainMaskView.trailingAnchor.constraint(equalTo: self.trailingAnchor).isActive = true
+
+        maskImageView.translatesAutoresizingMaskIntoConstraints = false
+        mainMaskView.topAnchor.constraint(equalTo: mainMaskView.topAnchor).isActive = true
+        mainMaskView.bottomAnchor.constraint(equalTo: mainMaskView.bottomAnchor).isActive = true
+        mainMaskView.leadingAnchor.constraint(equalTo: mainMaskView.leadingAnchor).isActive = true
+        mainMaskView.trailingAnchor.constraint(equalTo: mainMaskView.trailingAnchor).isActive = true
+
+        topMaskView.translatesAutoresizingMaskIntoConstraints = false
+        topMaskView.topAnchor.constraint(equalTo: mainMaskView.topAnchor).isActive = true
+        topMaskView.leadingAnchor.constraint(equalTo: mainMaskView.leadingAnchor).isActive = true
+        topMaskView.trailingAnchor.constraint(equalTo: mainMaskView.trailingAnchor).isActive = true
+        topMaskView.heightAnchor.constraint(equalToConstant: 65).isActive = true
+
+        bottomMaskView.translatesAutoresizingMaskIntoConstraints = false
+        bottomMaskView.bottomAnchor.constraint(equalTo: mainMaskView.bottomAnchor).isActive = true
+        bottomMaskView.leadingAnchor.constraint(equalTo: mainMaskView.leadingAnchor).isActive = true
+        bottomMaskView.trailingAnchor.constraint(equalTo: mainMaskView.trailingAnchor).isActive = true
+        bottomMaskView.heightAnchor.constraint(equalToConstant: 50).isActive = true
+
         // Top views
-        if #available(iOS 9.0, *) {
-            backButton.translatesAutoresizingMaskIntoConstraints = false
-            backButton.leadingAnchor.constraint(equalTo: topMaskView.leadingAnchor).isActive = true
-            backButton.bottomAnchor.constraint(equalTo: topMaskView.bottomAnchor).isActive = true
-            backButton.widthAnchor.constraint(equalToConstant: 50).isActive = true
-            backButton.heightAnchor.constraint(equalToConstant: 50).isActive = true
-        }
-        if #available(iOS 9.0, *) {
-            titleLabel.translatesAutoresizingMaskIntoConstraints = false
-            titleLabel.leadingAnchor.constraint(equalTo: backButton.trailingAnchor).isActive = true
-            titleLabel.centerYAnchor.constraint(equalTo: backButton.centerYAnchor).isActive = true
-        }
-        if #available(iOS 9.0, *) {
-            chooseDefitionView.translatesAutoresizingMaskIntoConstraints = false
-            chooseDefitionView.trailingAnchor.constraint(equalTo: topMaskView.trailingAnchor, constant: -20).isActive = true
-            chooseDefitionView.topAnchor.constraint(equalTo: titleLabel.topAnchor, constant: -4).isActive = true
-            chooseDefitionView.widthAnchor.constraint(equalToConstant: 60).isActive = true
-            chooseDefinitionHeightConstraint = chooseDefitionView.heightAnchor.constraint(equalToConstant: 30)
-            chooseDefinitionHeightConstraint.isActive = true
-        }
+        backButton.translatesAutoresizingMaskIntoConstraints = false
+        backButton.leadingAnchor.constraint(equalTo: topMaskView.leadingAnchor).isActive = true
+        backButton.bottomAnchor.constraint(equalTo: topMaskView.bottomAnchor).isActive = true
+        backButton.widthAnchor.constraint(equalToConstant: 50).isActive = true
+        backButton.heightAnchor.constraint(equalToConstant: 50).isActive = true
+
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        titleLabel.leadingAnchor.constraint(equalTo: backButton.trailingAnchor).isActive = true
+        titleLabel.centerYAnchor.constraint(equalTo: backButton.centerYAnchor).isActive = true
+
+        chooseDefitionView.translatesAutoresizingMaskIntoConstraints = false
+        chooseDefitionView.trailingAnchor.constraint(equalTo: topMaskView.trailingAnchor, constant: -20).isActive = true
+        chooseDefitionView.topAnchor.constraint(equalTo: titleLabel.topAnchor, constant: -4).isActive = true
+        chooseDefitionView.widthAnchor.constraint(equalToConstant: 60).isActive = true
+        chooseDefinitionHeightConstraint = chooseDefitionView.heightAnchor.constraint(equalToConstant: 30)
+        chooseDefinitionHeightConstraint.isActive = true
+
         // Bottom views
-        if #available(iOS 9.0, *) {
-            playButton.translatesAutoresizingMaskIntoConstraints = false
-            playButton.leadingAnchor.constraint(equalTo: bottomMaskView.leadingAnchor).isActive = true
-            playButton.bottomAnchor.constraint(equalTo: bottomMaskView.bottomAnchor).isActive = true
-            playButton.widthAnchor.constraint(equalToConstant: 50).isActive = true
-            playButton.heightAnchor.constraint(equalToConstant: 50).isActive = true
-        }
-        if #available(iOS 9.0, *) {
-            currentTimeLabel.translatesAutoresizingMaskIntoConstraints = false
-            currentTimeLabel.leadingAnchor.constraint(equalTo: playButton.trailingAnchor).isActive = true
-            currentTimeLabel.centerYAnchor.constraint(equalTo: playButton.centerYAnchor).isActive = true
-            currentTimeLabel.widthAnchor.constraint(equalToConstant: 40).isActive = true
-        }
-        if #available(iOS 9.0, *) {
-            timeSlider.translatesAutoresizingMaskIntoConstraints = false
-            let tempLeadingConstraint = timeSlider.leadingAnchor.constraint(equalTo: currentTimeLabel.trailingAnchor, constant: 10)
-            tempLeadingConstraint.priority = UILayoutPriority(750)
-            tempLeadingConstraint.isActive = true
-            timeSlider.centerYAnchor.constraint(equalTo: currentTimeLabel.centerYAnchor).isActive = true
-            timeSlider.heightAnchor.constraint(equalToConstant: 30).isActive = true
-        }
-        if #available(iOS 9.0, *) {
-            progressView.translatesAutoresizingMaskIntoConstraints = false
-            progressView.leadingAnchor.constraint(equalTo: timeSlider.leadingAnchor).isActive = true
-            progressView.trailingAnchor.constraint(equalTo: timeSlider.trailingAnchor).isActive = true
-            progressView.centerYAnchor.constraint(equalTo: currentTimeLabel.centerYAnchor).isActive = true
-            progressView.heightAnchor.constraint(equalToConstant: 2).isActive = true
-        }
-        if #available(iOS 9.0, *) {
-            totalTimeLabel.translatesAutoresizingMaskIntoConstraints = false
-            totalTimeLabel.leadingAnchor.constraint(equalTo: timeSlider.trailingAnchor, constant: 5).isActive = true
-            totalTimeLabel.centerYAnchor.constraint(equalTo: currentTimeLabel.centerYAnchor).isActive = true
-            totalTimeLabel.widthAnchor.constraint(equalToConstant: 40).isActive = true
-        }
-        if #available(iOS 9.0, *) {
-            fullscreenButton.translatesAutoresizingMaskIntoConstraints = false
-            fullscreenButton.leadingAnchor.constraint(equalTo: totalTimeLabel.trailingAnchor).isActive = true
-            fullscreenButton.trailingAnchor.constraint(equalTo: bottomMaskView.trailingAnchor).isActive = true
-            fullscreenButton.centerYAnchor.constraint(equalTo: currentTimeLabel.centerYAnchor).isActive = true
-            fullscreenButton.widthAnchor.constraint(equalToConstant: 50).isActive = true
-            fullscreenButton.heightAnchor.constraint(equalToConstant: 50).isActive = true
-        }
-        if #available(iOS 9.0, *) {
-            loadingIndector.translatesAutoresizingMaskIntoConstraints = false
-            loadingIndector.centerXAnchor.constraint(equalTo: mainMaskView.centerXAnchor).isActive = true
-            loadingIndector.centerYAnchor.constraint(equalTo: mainMaskView.centerYAnchor).isActive = true
-        }
+        playButton.translatesAutoresizingMaskIntoConstraints = false
+        playButton.leadingAnchor.constraint(equalTo: bottomMaskView.leadingAnchor).isActive = true
+        playButton.bottomAnchor.constraint(equalTo: bottomMaskView.bottomAnchor).isActive = true
+        playButton.widthAnchor.constraint(equalToConstant: 50).isActive = true
+        playButton.heightAnchor.constraint(equalToConstant: 50).isActive = true
+
+        currentTimeLabel.translatesAutoresizingMaskIntoConstraints = false
+        currentTimeLabel.leadingAnchor.constraint(equalTo: playButton.trailingAnchor).isActive = true
+        currentTimeLabel.centerYAnchor.constraint(equalTo: playButton.centerYAnchor).isActive = true
+        currentTimeLabel.widthAnchor.constraint(equalToConstant: 40).isActive = true
+
+        timeSlider.translatesAutoresizingMaskIntoConstraints = false
+        let tempLeadingConstraint = timeSlider.leadingAnchor.constraint(equalTo: currentTimeLabel.trailingAnchor, constant: 10)
+        tempLeadingConstraint.priority = UILayoutPriority(750)
+        tempLeadingConstraint.isActive = true
+        timeSlider.centerYAnchor.constraint(equalTo: currentTimeLabel.centerYAnchor).isActive = true
+        timeSlider.heightAnchor.constraint(equalToConstant: 30).isActive = true
+
+        progressView.translatesAutoresizingMaskIntoConstraints = false
+        progressView.leadingAnchor.constraint(equalTo: timeSlider.leadingAnchor).isActive = true
+        progressView.trailingAnchor.constraint(equalTo: timeSlider.trailingAnchor).isActive = true
+        progressView.centerYAnchor.constraint(equalTo: currentTimeLabel.centerYAnchor).isActive = true
+        progressView.heightAnchor.constraint(equalToConstant: 2).isActive = true
+
+        totalTimeLabel.translatesAutoresizingMaskIntoConstraints = false
+        totalTimeLabel.leadingAnchor.constraint(equalTo: timeSlider.trailingAnchor, constant: 5).isActive = true
+        totalTimeLabel.centerYAnchor.constraint(equalTo: currentTimeLabel.centerYAnchor).isActive = true
+        totalTimeLabel.widthAnchor.constraint(equalToConstant: 40).isActive = true
+
+        fullscreenButton.translatesAutoresizingMaskIntoConstraints = false
+        fullscreenButton.leadingAnchor.constraint(equalTo: totalTimeLabel.trailingAnchor).isActive = true
+        fullscreenButton.trailingAnchor.constraint(equalTo: bottomMaskView.trailingAnchor).isActive = true
+        fullscreenButton.centerYAnchor.constraint(equalTo: currentTimeLabel.centerYAnchor).isActive = true
+        fullscreenButton.widthAnchor.constraint(equalToConstant: 50).isActive = true
+        fullscreenButton.heightAnchor.constraint(equalToConstant: 50).isActive = true
+
+        loadingIndector.translatesAutoresizingMaskIntoConstraints = false
+        loadingIndector.centerXAnchor.constraint(equalTo: mainMaskView.centerXAnchor).isActive = true
+        loadingIndector.centerYAnchor.constraint(equalTo: mainMaskView.centerYAnchor).isActive = true
+
         // View to show when slide to seek
-        if #available(iOS 9.0, *) {
-            seekToView.translatesAutoresizingMaskIntoConstraints = false
-            seekToView.centerXAnchor.constraint(equalTo: self.centerXAnchor).isActive = true
-            seekToView.centerYAnchor.constraint(equalTo: self.centerYAnchor).isActive = true
-            seekToView.widthAnchor.constraint(equalToConstant: 100).isActive = true
-            seekToView.heightAnchor.constraint(equalToConstant: 40).isActive = true
-        }
-        if #available(iOS 9.0, *) {
-            seekToViewImage.translatesAutoresizingMaskIntoConstraints = false
-            seekToViewImage.leadingAnchor.constraint(equalTo: seekToView.leadingAnchor, constant: 15).isActive = true
-            seekToViewImage.centerYAnchor.constraint(equalTo: seekToView.centerYAnchor).isActive = true
-            seekToViewImage.widthAnchor.constraint(equalToConstant: 25).isActive = true
-            seekToViewImage.heightAnchor.constraint(equalToConstant: 15).isActive = true
-        }
-        if #available(iOS 9.0, *) {
-            seekToLabel.translatesAutoresizingMaskIntoConstraints = false
-            seekToLabel.leadingAnchor.constraint(equalTo: seekToViewImage.trailingAnchor, constant: 10).isActive = true
-            seekToLabel.centerYAnchor.constraint(equalTo: seekToView.centerYAnchor).isActive = true
-        }
-        if #available(iOS 9.0, *) {
-            replayButton.translatesAutoresizingMaskIntoConstraints = false
-            replayButton.leadingAnchor.constraint(equalTo: seekToViewImage.trailingAnchor, constant: 10).isActive = true
-            replayButton.centerXAnchor.constraint(equalTo: mainMaskView.centerXAnchor).isActive = true
-            replayButton.centerYAnchor.constraint(equalTo: mainMaskView.centerYAnchor).isActive = true
-            replayButton.heightAnchor.constraint(equalToConstant:50).isActive = true
-        }
-        if #available(iOS 9.0, *) {
-            subtitleBackView.translatesAutoresizingMaskIntoConstraints = false
-            subtitleBackView.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -5).isActive = true
-            subtitleBackView.centerXAnchor.constraint(equalTo: self.centerXAnchor).isActive = true
-            let tempWidthConstraint = subtitleBackView.widthAnchor.constraint(lessThanOrEqualTo: self.widthAnchor, multiplier: 1, constant: -10)
-            tempWidthConstraint.priority = UILayoutPriority(750)
-            tempWidthConstraint.isActive = true
-        }
-        if #available(iOS 9.0, *) {
-            subtitleLabel.translatesAutoresizingMaskIntoConstraints = false
-            subtitleLabel.leadingAnchor.constraint(equalTo: subtitleBackView.leadingAnchor, constant: 10).isActive = true
-            subtitleLabel.trailingAnchor.constraint(equalTo: subtitleBackView.trailingAnchor, constant: -10).isActive = true
-            subtitleLabel.topAnchor.constraint(equalTo: subtitleBackView.topAnchor, constant: 2).isActive = true
-            subtitleLabel.bottomAnchor.constraint(equalTo: subtitleBackView.bottomAnchor, constant: -2).isActive = true
-        }
+        seekToView.translatesAutoresizingMaskIntoConstraints = false
+        seekToView.centerXAnchor.constraint(equalTo: self.centerXAnchor).isActive = true
+        seekToView.centerYAnchor.constraint(equalTo: self.centerYAnchor).isActive = true
+        seekToView.widthAnchor.constraint(equalToConstant: 100).isActive = true
+        seekToView.heightAnchor.constraint(equalToConstant: 40).isActive = true
+
+        seekToViewImage.translatesAutoresizingMaskIntoConstraints = false
+        seekToViewImage.leadingAnchor.constraint(equalTo: seekToView.leadingAnchor, constant: 15).isActive = true
+        seekToViewImage.centerYAnchor.constraint(equalTo: seekToView.centerYAnchor).isActive = true
+        seekToViewImage.widthAnchor.constraint(equalToConstant: 25).isActive = true
+        seekToViewImage.heightAnchor.constraint(equalToConstant: 15).isActive = true
+
+        seekToLabel.translatesAutoresizingMaskIntoConstraints = false
+        seekToLabel.leadingAnchor.constraint(equalTo: seekToViewImage.trailingAnchor, constant: 10).isActive = true
+        seekToLabel.centerYAnchor.constraint(equalTo: seekToView.centerYAnchor).isActive = true
+
+        replayButton.translatesAutoresizingMaskIntoConstraints = false
+        replayButton.leadingAnchor.constraint(equalTo: seekToViewImage.trailingAnchor, constant: 10).isActive = true
+        replayButton.centerXAnchor.constraint(equalTo: mainMaskView.centerXAnchor).isActive = true
+        replayButton.centerYAnchor.constraint(equalTo: mainMaskView.centerYAnchor).isActive = true
+        replayButton.heightAnchor.constraint(equalToConstant:50).isActive = true
+
+        subtitleBackView.translatesAutoresizingMaskIntoConstraints = false
+        subtitleBackView.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -5).isActive = true
+        subtitleBackView.centerXAnchor.constraint(equalTo: self.centerXAnchor).isActive = true
+        let tempWidthConstraint = subtitleBackView.widthAnchor.constraint(lessThanOrEqualTo: self.widthAnchor, multiplier: 1, constant: -10)
+        tempWidthConstraint.priority = UILayoutPriority(750)
+        tempWidthConstraint.isActive = true
+
+        subtitleLabel.translatesAutoresizingMaskIntoConstraints = false
+        subtitleLabel.leadingAnchor.constraint(equalTo: subtitleBackView.leadingAnchor, constant: 10).isActive = true
+        subtitleLabel.trailingAnchor.constraint(equalTo: subtitleBackView.trailingAnchor, constant: -10).isActive = true
+        subtitleLabel.topAnchor.constraint(equalTo: subtitleBackView.topAnchor, constant: 2).isActive = true
+        subtitleLabel.bottomAnchor.constraint(equalTo: subtitleBackView.bottomAnchor, constant: -2).isActive = true
     }
     
     fileprivate func BMImageResourcePath(_ fileName: String) -> UIImage? {

--- a/Source/BMPlayerControlView.swift
+++ b/Source/BMPlayerControlView.swift
@@ -77,6 +77,7 @@ open class BMPlayerControlView: UIView {
     open var backButton         = UIButton(type : UIButtonType.custom)
     open var titleLabel         = UILabel()
     open var chooseDefitionView = UIView()
+    private var chooseDefinitionHeightConstraint : NSLayoutConstraint!
     
     /// bottom view
     open var currentTimeLabel = UILabel()
@@ -242,8 +243,10 @@ open class BMPlayerControlView: UIView {
                 if self.isFullscreen { self.chooseDefitionView.alpha = 1.0 }
             } else {
                 self.replayButton.isHidden = true
-                self.chooseDefitionView.snp.updateConstraints { (make) in
-                    make.height.equalTo(35)
+                if #available(iOS 9.0, *) {
+                    self.chooseDefinitionHeightConstraint.isActive = false
+                    self.chooseDefinitionHeightConstraint = self.chooseDefitionView.heightAnchor.constraint(equalToConstant: 35)
+                    self.chooseDefinitionHeightConstraint.isActive = true
                 }
                 self.chooseDefitionView.alpha = 0.0
             }
@@ -349,13 +352,13 @@ open class BMPlayerControlView: UIView {
             button.setTitle("\(resource.definitions[button.tag].definition)", for: UIControlState())
             chooseDefitionView.addSubview(button)
             button.addTarget(self, action: #selector(self.onDefinitionSelected(_:)), for: UIControlEvents.touchUpInside)
-            button.snp.makeConstraints({ (make) in
-                make.top.equalTo(chooseDefitionView.snp.top).offset(35 * i)
-                make.width.equalTo(50)
-                make.height.equalTo(25)
-                make.centerX.equalTo(chooseDefitionView)
-            })
-            
+            if #available(iOS 9.0, *) {
+                button.translatesAutoresizingMaskIntoConstraints = false
+                button.topAnchor.constraint(equalTo: chooseDefitionView.topAnchor, constant: CGFloat(35 * i)).isActive = true
+                button.widthAnchor.constraint(equalToConstant: 50).isActive = true
+                button.heightAnchor.constraint(equalToConstant: 25).isActive = true
+                button.centerXAnchor.constraint(equalTo: chooseDefitionView.centerXAnchor).isActive = true
+            }
             if resource.definitions.count == 1 {
                 button.isEnabled = false
                 button.isHidden = true
@@ -434,8 +437,10 @@ open class BMPlayerControlView: UIView {
     
     @objc fileprivate func onDefinitionSelected(_ button:UIButton) {
         let height = isSelectecDefitionViewOpened ? 35 : resource!.definitions.count * 40
-        chooseDefitionView.snp.updateConstraints { (make) in
-            make.height.equalTo(height)
+        if #available(iOS 9.0, *) {
+            chooseDefinitionHeightConstraint.isActive = false
+            chooseDefinitionHeightConstraint = chooseDefitionView.heightAnchor.constraint(equalToConstant: CGFloat(height))
+            chooseDefinitionHeightConstraint.isActive = true
         }
         
         UIView.animate(withDuration: 0.3, animations: {
@@ -592,123 +597,144 @@ open class BMPlayerControlView: UIView {
     
     func addSnapKitConstraint() {
         // Main mask view
-        mainMaskView.snp.makeConstraints { (make) in
-            make.edges.equalTo(self)
+        if #available(iOS 9.0, *) {
+            mainMaskView.translatesAutoresizingMaskIntoConstraints = false
+            mainMaskView.topAnchor.constraint(equalTo: self.topAnchor).isActive = true
+            mainMaskView.bottomAnchor.constraint(equalTo: self.bottomAnchor).isActive = true
+            mainMaskView.leadingAnchor.constraint(equalTo: self.leadingAnchor).isActive = true
+            mainMaskView.trailingAnchor.constraint(equalTo: self.trailingAnchor).isActive = true
         }
-        
-        maskImageView.snp.makeConstraints { (make) in
-            make.edges.equalTo(mainMaskView)
+        if #available(iOS 9.0, *) {
+            maskImageView.translatesAutoresizingMaskIntoConstraints = false
+            mainMaskView.topAnchor.constraint(equalTo: mainMaskView.topAnchor).isActive = true
+            mainMaskView.bottomAnchor.constraint(equalTo: mainMaskView.bottomAnchor).isActive = true
+            mainMaskView.leadingAnchor.constraint(equalTo: mainMaskView.leadingAnchor).isActive = true
+            mainMaskView.trailingAnchor.constraint(equalTo: mainMaskView.trailingAnchor).isActive = true
         }
-        
-        
-        topMaskView.snp.makeConstraints { (make) in
-            make.top.left.right.equalTo(mainMaskView)
-            make.height.equalTo(65)
+        if #available(iOS 9.0, *) {
+            topMaskView.translatesAutoresizingMaskIntoConstraints = false
+            topMaskView.topAnchor.constraint(equalTo: mainMaskView.topAnchor).isActive = true
+            topMaskView.leadingAnchor.constraint(equalTo: mainMaskView.leadingAnchor).isActive = true
+            topMaskView.trailingAnchor.constraint(equalTo: mainMaskView.trailingAnchor).isActive = true
+            topMaskView.heightAnchor.constraint(equalToConstant: 65).isActive = true
         }
-        
-        bottomMaskView.snp.makeConstraints { (make) in
-            make.bottom.left.right.equalTo(mainMaskView)
-            make.height.equalTo(50)
+        if #available(iOS 9.0, *) {
+            bottomMaskView.translatesAutoresizingMaskIntoConstraints = false
+            bottomMaskView.bottomAnchor.constraint(equalTo: mainMaskView.bottomAnchor).isActive = true
+            bottomMaskView.leadingAnchor.constraint(equalTo: mainMaskView.leadingAnchor).isActive = true
+            bottomMaskView.trailingAnchor.constraint(equalTo: mainMaskView.trailingAnchor).isActive = true
+            bottomMaskView.heightAnchor.constraint(equalToConstant: 50).isActive = true
         }
-        
         // Top views
-        backButton.snp.makeConstraints { (make) in
-            make.width.height.equalTo(50)
-            make.left.bottom.equalTo(topMaskView)
+        if #available(iOS 9.0, *) {
+            backButton.translatesAutoresizingMaskIntoConstraints = false
+            backButton.leadingAnchor.constraint(equalTo: topMaskView.leadingAnchor).isActive = true
+            backButton.bottomAnchor.constraint(equalTo: topMaskView.bottomAnchor).isActive = true
+            backButton.widthAnchor.constraint(equalToConstant: 50).isActive = true
+            backButton.heightAnchor.constraint(equalToConstant: 50).isActive = true
         }
-        
-        titleLabel.snp.makeConstraints { (make) in
-            make.left.equalTo(backButton.snp.right)
-            make.centerY.equalTo(backButton)
+        if #available(iOS 9.0, *) {
+            titleLabel.translatesAutoresizingMaskIntoConstraints = false
+            titleLabel.leadingAnchor.constraint(equalTo: backButton.trailingAnchor).isActive = true
+            titleLabel.centerYAnchor.constraint(equalTo: backButton.centerYAnchor).isActive = true
         }
-        
-        chooseDefitionView.snp.makeConstraints { (make) in
-            make.right.equalTo(topMaskView.snp.right).offset(-20)
-            make.top.equalTo(titleLabel.snp.top).offset(-4)
-            make.width.equalTo(60)
-            make.height.equalTo(30)
+        if #available(iOS 9.0, *) {
+            chooseDefitionView.translatesAutoresizingMaskIntoConstraints = false
+            chooseDefitionView.trailingAnchor.constraint(equalTo: topMaskView.trailingAnchor, constant: -20).isActive = true
+            chooseDefitionView.topAnchor.constraint(equalTo: titleLabel.topAnchor, constant: -4).isActive = true
+            chooseDefitionView.widthAnchor.constraint(equalToConstant: 60).isActive = true
+            chooseDefinitionHeightConstraint = chooseDefitionView.heightAnchor.constraint(equalToConstant: 30)
+            chooseDefinitionHeightConstraint.isActive = true
         }
-        
         // Bottom views
-        playButton.snp.makeConstraints { (make) in
-            make.width.equalTo(50)
-            make.height.equalTo(50)
-            make.left.bottom.equalTo(bottomMaskView)
+        if #available(iOS 9.0, *) {
+            playButton.translatesAutoresizingMaskIntoConstraints = false
+            playButton.leadingAnchor.constraint(equalTo: bottomMaskView.leadingAnchor).isActive = true
+            playButton.bottomAnchor.constraint(equalTo: bottomMaskView.bottomAnchor).isActive = true
+            playButton.widthAnchor.constraint(equalToConstant: 50).isActive = true
+            playButton.heightAnchor.constraint(equalToConstant: 50).isActive = true
         }
-        
-        currentTimeLabel.snp.makeConstraints { (make) in
-            make.left.equalTo(playButton.snp.right)
-            make.centerY.equalTo(playButton)
-            make.width.equalTo(40)
+        if #available(iOS 9.0, *) {
+            currentTimeLabel.translatesAutoresizingMaskIntoConstraints = false
+            currentTimeLabel.leadingAnchor.constraint(equalTo: playButton.trailingAnchor).isActive = true
+            currentTimeLabel.centerYAnchor.constraint(equalTo: playButton.centerYAnchor).isActive = true
+            currentTimeLabel.widthAnchor.constraint(equalToConstant: 40).isActive = true
         }
-        
-        timeSlider.snp.makeConstraints { (make) in
-            make.centerY.equalTo(currentTimeLabel)
-            make.left.equalTo(currentTimeLabel.snp.right).offset(10).priority(750)
-            make.height.equalTo(30)
+        if #available(iOS 9.0, *) {
+            timeSlider.translatesAutoresizingMaskIntoConstraints = false
+            let tempLeadingConstraint = timeSlider.leadingAnchor.constraint(equalTo: currentTimeLabel.trailingAnchor, constant: 10)
+            tempLeadingConstraint.priority = UILayoutPriority(750)
+            tempLeadingConstraint.isActive = true
+            timeSlider.centerYAnchor.constraint(equalTo: currentTimeLabel.centerYAnchor).isActive = true
+            timeSlider.heightAnchor.constraint(equalToConstant: 30).isActive = true
         }
-        
-        progressView.snp.makeConstraints { (make) in
-            make.centerY.left.right.equalTo(timeSlider)
-            make.height.equalTo(2)
+        if #available(iOS 9.0, *) {
+            progressView.translatesAutoresizingMaskIntoConstraints = false
+            progressView.leadingAnchor.constraint(equalTo: timeSlider.leadingAnchor).isActive = true
+            progressView.trailingAnchor.constraint(equalTo: timeSlider.trailingAnchor).isActive = true
+            progressView.centerYAnchor.constraint(equalTo: currentTimeLabel.centerYAnchor).isActive = true
+            progressView.heightAnchor.constraint(equalToConstant: 2).isActive = true
         }
-        
-        totalTimeLabel.snp.makeConstraints { (make) in
-            make.centerY.equalTo(currentTimeLabel)
-            make.left.equalTo(timeSlider.snp.right).offset(5)
-            make.width.equalTo(40)
+        if #available(iOS 9.0, *) {
+            totalTimeLabel.translatesAutoresizingMaskIntoConstraints = false
+            totalTimeLabel.leadingAnchor.constraint(equalTo: timeSlider.trailingAnchor, constant: 5).isActive = true
+            totalTimeLabel.centerYAnchor.constraint(equalTo: currentTimeLabel.centerYAnchor).isActive = true
+            totalTimeLabel.widthAnchor.constraint(equalToConstant: 40).isActive = true
         }
-        
-        fullscreenButton.snp.makeConstraints { (make) in
-            make.width.equalTo(50)
-            make.height.equalTo(50)
-            make.centerY.equalTo(currentTimeLabel)
-            make.left.equalTo(totalTimeLabel.snp.right)
-            make.right.equalTo(bottomMaskView.snp.right)
+        if #available(iOS 9.0, *) {
+            fullscreenButton.translatesAutoresizingMaskIntoConstraints = false
+            fullscreenButton.leadingAnchor.constraint(equalTo: totalTimeLabel.trailingAnchor).isActive = true
+            fullscreenButton.trailingAnchor.constraint(equalTo: bottomMaskView.trailingAnchor).isActive = true
+            fullscreenButton.centerYAnchor.constraint(equalTo: currentTimeLabel.centerYAnchor).isActive = true
+            fullscreenButton.widthAnchor.constraint(equalToConstant: 50).isActive = true
+            fullscreenButton.heightAnchor.constraint(equalToConstant: 50).isActive = true
         }
-        
-        
-        loadingIndector.snp.makeConstraints { (make) in
-            make.centerX.equalTo(mainMaskView.snp.centerX).offset(0)
-            make.centerY.equalTo(mainMaskView.snp.centerY).offset(0)
+        if #available(iOS 9.0, *) {
+            loadingIndector.translatesAutoresizingMaskIntoConstraints = false
+            loadingIndector.centerXAnchor.constraint(equalTo: mainMaskView.centerXAnchor).isActive = true
+            loadingIndector.centerYAnchor.constraint(equalTo: mainMaskView.centerYAnchor).isActive = true
         }
-        
         // View to show when slide to seek
-        seekToView.snp.makeConstraints { (make) in
-            make.center.equalTo(self.snp.center)
-            make.width.equalTo(100)
-            make.height.equalTo(40)
+        if #available(iOS 9.0, *) {
+            seekToView.translatesAutoresizingMaskIntoConstraints = false
+            seekToView.centerXAnchor.constraint(equalTo: self.centerXAnchor).isActive = true
+            seekToView.centerYAnchor.constraint(equalTo: self.centerYAnchor).isActive = true
+            seekToView.widthAnchor.constraint(equalToConstant: 100).isActive = true
+            seekToView.heightAnchor.constraint(equalToConstant: 40).isActive = true
         }
-        
-        seekToViewImage.snp.makeConstraints { (make) in
-            make.left.equalTo(seekToView.snp.left).offset(15)
-            make.centerY.equalTo(seekToView.snp.centerY)
-            make.height.equalTo(15)
-            make.width.equalTo(25)
+        if #available(iOS 9.0, *) {
+            seekToViewImage.translatesAutoresizingMaskIntoConstraints = false
+            seekToViewImage.leadingAnchor.constraint(equalTo: seekToView.leadingAnchor, constant: 15).isActive = true
+            seekToViewImage.centerYAnchor.constraint(equalTo: seekToView.centerYAnchor).isActive = true
+            seekToViewImage.widthAnchor.constraint(equalToConstant: 25).isActive = true
+            seekToViewImage.heightAnchor.constraint(equalToConstant: 15).isActive = true
         }
-        
-        seekToLabel.snp.makeConstraints { (make) in
-            make.left.equalTo(seekToViewImage.snp.right).offset(10)
-            make.centerY.equalTo(seekToView.snp.centerY)
+        if #available(iOS 9.0, *) {
+            seekToLabel.translatesAutoresizingMaskIntoConstraints = false
+            seekToLabel.leadingAnchor.constraint(equalTo: seekToViewImage.trailingAnchor, constant: 10).isActive = true
+            seekToLabel.centerYAnchor.constraint(equalTo: seekToView.centerYAnchor).isActive = true
         }
-        
-        replayButton.snp.makeConstraints { (make) in
-            make.centerX.equalTo(mainMaskView.snp.centerX)
-            make.centerY.equalTo(mainMaskView.snp.centerY)
-            make.width.height.equalTo(50)
+        if #available(iOS 9.0, *) {
+            replayButton.translatesAutoresizingMaskIntoConstraints = false
+            replayButton.leadingAnchor.constraint(equalTo: seekToViewImage.trailingAnchor, constant: 10).isActive = true
+            replayButton.centerXAnchor.constraint(equalTo: mainMaskView.centerXAnchor).isActive = true
+            replayButton.centerYAnchor.constraint(equalTo: mainMaskView.centerYAnchor).isActive = true
+            replayButton.heightAnchor.constraint(equalToConstant:50).isActive = true
         }
-        
-        subtitleBackView.snp.makeConstraints {
-            $0.bottom.equalTo(snp.bottom).offset(-5)
-            $0.centerX.equalTo(snp.centerX)
-            $0.width.lessThanOrEqualTo(snp.width).offset(-10).priority(750)
+        if #available(iOS 9.0, *) {
+            subtitleBackView.translatesAutoresizingMaskIntoConstraints = false
+            subtitleBackView.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -5).isActive = true
+            subtitleBackView.centerXAnchor.constraint(equalTo: self.centerXAnchor).isActive = true
+            let tempWidthConstraint = subtitleBackView.widthAnchor.constraint(lessThanOrEqualTo: self.widthAnchor, multiplier: 1, constant: -10)
+            tempWidthConstraint.priority = UILayoutPriority(750)
+            tempWidthConstraint.isActive = true
         }
-        
-        subtitleLabel.snp.makeConstraints {
-            $0.left.equalTo(subtitleBackView.snp.left).offset(10)
-            $0.right.equalTo(subtitleBackView.snp.right).offset(-10)
-            $0.top.equalTo(subtitleBackView.snp.top).offset(2)
-            $0.bottom.equalTo(subtitleBackView.snp.bottom).offset(-2)
+        if #available(iOS 9.0, *) {
+            subtitleLabel.translatesAutoresizingMaskIntoConstraints = false
+            subtitleLabel.leadingAnchor.constraint(equalTo: subtitleBackView.leadingAnchor, constant: 10).isActive = true
+            subtitleLabel.trailingAnchor.constraint(equalTo: subtitleBackView.trailingAnchor, constant: -10).isActive = true
+            subtitleLabel.topAnchor.constraint(equalTo: subtitleBackView.topAnchor, constant: 2).isActive = true
+            subtitleLabel.bottomAnchor.constraint(equalTo: subtitleBackView.bottomAnchor, constant: -2).isActive = true
         }
     }
     


### PR DESCRIPTION
Change all usage of Snapkit to use iOS provided constraint functionality through anchors. This allows the pod to be lighter when SnapKit is removed. It also reduces possible issues with dependencies. I also removed usage of SnapKit in the example project and replaced it with anchors so there is no reference to SnapKit any longer and it can be removed as a dependency in the future from this project.

I also fixed the UI for the example code, which had the video being covered by the navigation controller nav bar. I added extra code to take care of the edge case when the VideoPlayViewController is opened in landscape mode so that the nav bar will disappear. I've also added a BMError enum type with a raw value to be printed as a fatal error in case the pod is used in in less than iOS 9.

These changes will cause the pod to no longer work for iOS 8, since I used anchors as the constraint solution. It should be noted that little over 1% of users are still using iOS 8.

I also removed the usage of the deprecated method: setStatusBarHidden:animated: in UIApplication.  I think it's better to allow the outside application to decided how the status bar should be hidden or not hidden. As of the now the status bar is automatically hidden in landscape mode as per the example. 