### PR TITLE
Fix some typos and code formation

### DIFF
--- a/Source/BMPlayerClearityChooseButton.swift
+++ b/Source/BMPlayerClearityChooseButton.swift
@@ -23,7 +23,7 @@ class BMPlayerClearityChooseButton: UIButton {
         self.titleLabel?.font   = UIFont.systemFont(ofSize: 12)
         self.layer.cornerRadius = 2
         self.layer.borderWidth  = 1
-        self.layer.borderColor  = UIColor ( red: 1.0, green: 1.0, blue: 1.0, alpha: 0.8 ).cgColor
-        self.setTitleColor(UIColor ( red: 1.0, green: 1.0, blue: 1.0, alpha: 0.9 ), for: .normal)
+        self.layer.borderColor  = UIColor(white: 1, alpha: 0.8).cgColor
+        self.setTitleColor(UIColor(white: 1, alpha: 0.9), for: .normal)
     }
 }

--- a/Source/BMPlayerControlView.swift
+++ b/Source/BMPlayerControlView.swift
@@ -17,7 +17,7 @@ import NVActivityIndicatorView
      - parameter controlView: control view
      - parameter index:       index of definition
      */
-    func controlView(controlView: BMPlayerControlView, didChooseDefition index: Int)
+    func controlView(controlView: BMPlayerControlView, didChooseDefinition index: Int)
     
     /**
      call when control view pressed an button
@@ -57,41 +57,41 @@ open class BMPlayerControlView: UIView {
     open var isFullscreen  = false
     open var isMaskShowing = true
     
-    open var totalDuration:TimeInterval = 0
+    open var totalDuration: TimeInterval = 0
     open var delayItem: DispatchWorkItem?
     
     var playerLastState: BMPlayerState = .notSetURL
     
-    fileprivate var isSelectecDefitionViewOpened = false
+    fileprivate var isSelectDefinitionViewOpened = false
     
     // MARK: UI Components
     /// main views which contains the topMaskView and bottom mask view
-    open var mainMaskView    = UIView()
-    open var topMaskView     = UIView()
-    open var bottomMaskView  = UIView()
+    open var mainMaskView   = UIView()
+    open var topMaskView    = UIView()
+    open var bottomMaskView = UIView()
     
     /// Image view to show video cover
-    open var maskImageView   = UIImageView()
+    open var maskImageView = UIImageView()
     
     /// top views
-    open var backButton         = UIButton(type : UIButtonType.custom)
-    open var titleLabel         = UILabel()
-    open var chooseDefitionView = UIView()
+    open var backButton = UIButton(type : UIButtonType.custom)
+    open var titleLabel = UILabel()
+    open var chooseDefinitionView = UIView()
     
     /// bottom view
     open var currentTimeLabel = UILabel()
     open var totalTimeLabel   = UILabel()
     
     /// Progress slider
-    open var timeSlider       = BMTimeSlider()
+    open var timeSlider = BMTimeSlider()
     
     /// load progress view
-    open var progressView     = UIProgressView()
+    open var progressView = UIProgressView()
     
     /* play button
      playButton.isSelected = player.isPlaying
      */
-    open var playButton       = UIButton(type: UIButtonType.custom)
+    open var playButton = UIButton(type: UIButtonType.custom)
     
     /* fullScreen button
      fullScreenButton.isSelected = player.isFullscreen
@@ -100,7 +100,7 @@ open class BMPlayerControlView: UIView {
     
     open var subtitleLabel    = UILabel()
     open var subtitleBackView = UIView()
-    open var subtileAttrabute: [NSAttributedStringKey : Any]?
+    open var subtileAttribute: [NSAttributedStringKey : Any]?
     
     /// Activty Indector for loading
     open var loadingIndector  = NVActivityIndicatorView(frame:  CGRect(x: 0, y: 0, width: 30, height: 30))
@@ -136,7 +136,7 @@ open class BMPlayerControlView: UIView {
      - parameter loadedDuration: loaded duration
      - parameter totalDuration:  total duration
      */
-    open func loadedTimeDidChange(loadedDuration: TimeInterval , totalDuration: TimeInterval) {
+    open func loadedTimeDidChange(loadedDuration: TimeInterval, totalDuration: TimeInterval) {
         progressView.setProgress(Float(loadedDuration)/Float(totalDuration), animated: true)
     }
     
@@ -170,14 +170,14 @@ open class BMPlayerControlView: UIView {
      - parameter isAdd:         isAdd
      */
     open func showSeekToView(to toSecound: TimeInterval, total totalDuration:TimeInterval, isAdd: Bool) {
-        seekToView.isHidden   = false
+        seekToView.isHidden = false
         seekToLabel.text    = BMPlayer.formatSecondsToString(toSecound)
         
         let rotate = isAdd ? 0 : CGFloat(Double.pi)
         seekToViewImage.transform = CGAffineTransform(rotationAngle: rotate)
         
-        let targetTime      = BMPlayer.formatSecondsToString(toSecound)
-        timeSlider.value      = Float(toSecound / totalDuration)
+        let targetTime = BMPlayer.formatSecondsToString(toSecound)
+        timeSlider.value = Float(toSecound / totalDuration)
         currentTimeLabel.text = targetTime
     }
     
@@ -236,16 +236,16 @@ open class BMPlayerControlView: UIView {
         UIView.animate(withDuration: 0.3, animations: {
             self.topMaskView.alpha    = alpha
             self.bottomMaskView.alpha = alpha
-            self.mainMaskView.backgroundColor = UIColor ( red: 0.0, green: 0.0, blue: 0.0, alpha: isShow ? 0.4 : 0.0)
+            self.mainMaskView.backgroundColor = UIColor(white: 0, alpha: isShow ? 0.4 : 0.0)
             
             if isShow {
-                if self.isFullscreen { self.chooseDefitionView.alpha = 1.0 }
+                if self.isFullscreen { self.chooseDefinitionView.alpha = 1.0 }
             } else {
                 self.replayButton.isHidden = true
-                self.chooseDefitionView.snp.updateConstraints { (make) in
+                self.chooseDefinitionView.snp.updateConstraints { (make) in
                     make.height.equalTo(35)
                 }
-                self.chooseDefitionView.alpha = 0.0
+                self.chooseDefinitionView.alpha = 0.0
             }
             self.layoutIfNeeded()
         }) { (_) in
@@ -263,7 +263,7 @@ open class BMPlayerControlView: UIView {
     open func updateUI(_ isForFullScreen: Bool) {
         isFullscreen = isForFullScreen
         fullscreenButton.isSelected = isForFullScreen
-        chooseDefitionView.isHidden = !BMPlayerConf.enableChooseDefinition || !isForFullScreen
+        chooseDefinitionView.isHidden = !BMPlayerConf.enableChooseDefinition || !isForFullScreen
         if isForFullScreen {
             if BMPlayerConf.topBarShowInCase.rawValue == 2 {
                 topMaskView.isHidden = true
@@ -331,7 +331,7 @@ open class BMPlayerControlView: UIView {
         guard let resource = resource else {
             return
         }
-        for item in chooseDefitionView.subviews {
+        for item in chooseDefinitionView.subviews {
             item.removeFromSuperview()
         }
         
@@ -347,13 +347,13 @@ open class BMPlayerControlView: UIView {
             }
             
             button.setTitle("\(resource.definitions[button.tag].definition)", for: UIControlState())
-            chooseDefitionView.addSubview(button)
+            chooseDefinitionView.addSubview(button)
             button.addTarget(self, action: #selector(self.onDefinitionSelected(_:)), for: UIControlEvents.touchUpInside)
             button.snp.makeConstraints({ (make) in
-                make.top.equalTo(chooseDefitionView.snp.top).offset(35 * i)
+                make.top.equalTo(chooseDefinitionView.snp.top).offset(35 * i)
                 make.width.equalTo(50)
                 make.height.equalTo(25)
-                make.centerX.equalTo(chooseDefitionView)
+                make.centerX.equalTo(chooseDefinitionView)
             })
             
             if resource.definitions.count == 1 {
@@ -400,8 +400,6 @@ open class BMPlayerControlView: UIView {
         controlViewAnimation(isShow: !isMaskShowing)
     }
     
-    
-    
     // MARK: - handle UI slider actions
     @objc func progressSliderTouchBegan(_ sender: UISlider)  {
         delegate?.controlView(controlView: self, slider: sender, onSliderEvent: .touchDown)
@@ -426,25 +424,25 @@ open class BMPlayerControlView: UIView {
         if let group = subtitle.search(for: time) {
             subtitleBackView.isHidden = false
             subtitleLabel.attributedText = NSAttributedString(string: group.text,
-                                                              attributes: subtileAttrabute)
+                                                              attributes: subtileAttribute)
         } else {
             subtitleBackView.isHidden = true
         }
     }
     
     @objc fileprivate func onDefinitionSelected(_ button:UIButton) {
-        let height = isSelectecDefitionViewOpened ? 35 : resource!.definitions.count * 40
-        chooseDefitionView.snp.updateConstraints { (make) in
+        let height = isSelectDefinitionViewOpened ? 35 : resource!.definitions.count * 40
+        chooseDefinitionView.snp.updateConstraints { (make) in
             make.height.equalTo(height)
         }
         
         UIView.animate(withDuration: 0.3, animations: {
             self.layoutIfNeeded()
         })
-        isSelectecDefitionViewOpened = !isSelectecDefitionViewOpened
+        isSelectDefinitionViewOpened = !isSelectDefinitionViewOpened
         if selectedIndex != button.tag {
             selectedIndex = button.tag
-            delegate?.controlView(controlView: self, didChooseDefition: button.tag)
+            delegate?.controlView(controlView: self, didChooseDefinition: button.tag)
         }
         prepareChooseDefinitionView()
     }
@@ -495,12 +493,12 @@ open class BMPlayerControlView: UIView {
         mainMaskView.addSubview(bottomMaskView)
         mainMaskView.insertSubview(maskImageView, at: 0)
         mainMaskView.clipsToBounds = true
-        mainMaskView.backgroundColor = UIColor ( red: 0.0, green: 0.0, blue: 0.0, alpha: 0.4 )
+        mainMaskView.backgroundColor = UIColor(white: 0, alpha: 0.4 )
         
         // Top views
         topMaskView.addSubview(backButton)
         topMaskView.addSubview(titleLabel)
-        addSubview(chooseDefitionView)
+        addSubview(chooseDefinitionView)
         
         backButton.tag = BMPlayerControlView.ButtonType.back.rawValue
         backButton.setImage(BMImageResourcePath("Pod_Asset_BMPlayer_back"), for: .normal)
@@ -510,7 +508,7 @@ open class BMPlayerControlView: UIView {
         titleLabel.text      = ""
         titleLabel.font      = UIFont.systemFont(ofSize: 16)
         
-        chooseDefitionView.clipsToBounds = true
+        chooseDefinitionView.clipsToBounds = true
         
         // Bottom views
         bottomMaskView.addSubview(playButton)
@@ -563,8 +561,8 @@ open class BMPlayerControlView: UIView {
         
         mainMaskView.addSubview(loadingIndector)
         
-        loadingIndector.type             = BMPlayerConf.loaderType
-        loadingIndector.color            = BMPlayerConf.tintColor
+        loadingIndector.type  = BMPlayerConf.loaderType
+        loadingIndector.color = BMPlayerConf.tintColor
         
         // View to show when slide to seek
         addSubview(seekToView)
@@ -576,7 +574,7 @@ open class BMPlayerControlView: UIView {
         seekToView.backgroundColor      = UIColor ( red: 0.0, green: 0.0, blue: 0.0, alpha: 0.7 )
         seekToView.layer.cornerRadius   = 4
         seekToView.layer.masksToBounds  = true
-        seekToView.isHidden               = true
+        seekToView.isHidden             = true
         
         seekToViewImage.image = BMImageResourcePath("Pod_Asset_BMPlayer_seek_to_image")
         
@@ -600,7 +598,6 @@ open class BMPlayerControlView: UIView {
             make.edges.equalTo(mainMaskView)
         }
         
-        
         topMaskView.snp.makeConstraints { (make) in
             make.top.left.right.equalTo(mainMaskView)
             make.height.equalTo(65)
@@ -622,7 +619,7 @@ open class BMPlayerControlView: UIView {
             make.centerY.equalTo(backButton)
         }
         
-        chooseDefitionView.snp.makeConstraints { (make) in
+        chooseDefinitionView.snp.makeConstraints { (make) in
             make.right.equalTo(topMaskView.snp.right).offset(-20)
             make.top.equalTo(titleLabel.snp.top).offset(-4)
             make.width.equalTo(60)
@@ -666,7 +663,6 @@ open class BMPlayerControlView: UIView {
             make.left.equalTo(totalTimeLabel.snp.right)
             make.right.equalTo(bottomMaskView.snp.right)
         }
-        
         
         loadingIndector.snp.makeConstraints { (make) in
             make.centerX.equalTo(mainMaskView.snp.centerX).offset(0)
@@ -714,8 +710,7 @@ open class BMPlayerControlView: UIView {
     
     fileprivate func BMImageResourcePath(_ fileName: String) -> UIImage? {
         let bundle = Bundle(for: BMPlayer.self)
-        let image  = UIImage(named: fileName, in: bundle, compatibleWith: nil)
-        return image
+        return UIImage(named: fileName, in: bundle, compatibleWith: nil)
     }
 }
 

--- a/Source/BMPlayerControlView.swift
+++ b/Source/BMPlayerControlView.swift
@@ -74,11 +74,13 @@ open class BMPlayerControlView: UIView {
     open var maskImageView = UIImageView()
     
     /// top views
+    open var topWrapperView = UIView()
     open var backButton = UIButton(type : UIButtonType.custom)
     open var titleLabel = UILabel()
     open var chooseDefinitionView = UIView()
     
     /// bottom view
+    open var bottomWrapperView = UIView()
     open var currentTimeLabel = UILabel()
     open var totalTimeLabel   = UILabel()
     
@@ -508,9 +510,10 @@ open class BMPlayerControlView: UIView {
         mainMaskView.backgroundColor = UIColor(white: 0, alpha: 0.4 )
         
         // Top views
-        topMaskView.addSubview(backButton)
-        topMaskView.addSubview(titleLabel)
-        addSubview(chooseDefinitionView)
+        topMaskView.addSubview(topWrapperView)
+        topWrapperView.addSubview(backButton)
+        topWrapperView.addSubview(titleLabel)
+        topWrapperView.addSubview(chooseDefinitionView)
         
         backButton.tag = BMPlayerControlView.ButtonType.back.rawValue
         backButton.setImage(BMImageResourcePath("Pod_Asset_BMPlayer_back"), for: .normal)
@@ -523,12 +526,13 @@ open class BMPlayerControlView: UIView {
         chooseDefinitionView.clipsToBounds = true
         
         // Bottom views
-        bottomMaskView.addSubview(playButton)
-        bottomMaskView.addSubview(currentTimeLabel)
-        bottomMaskView.addSubview(totalTimeLabel)
-        bottomMaskView.addSubview(progressView)
-        bottomMaskView.addSubview(timeSlider)
-        bottomMaskView.addSubview(fullscreenButton)
+        bottomMaskView.addSubview(bottomWrapperView)
+        bottomWrapperView.addSubview(playButton)
+        bottomWrapperView.addSubview(currentTimeLabel)
+        bottomWrapperView.addSubview(totalTimeLabel)
+        bottomWrapperView.addSubview(progressView)
+        bottomWrapperView.addSubview(timeSlider)
+        bottomWrapperView.addSubview(fullscreenButton)
         
         playButton.tag = BMPlayerControlView.ButtonType.play.rawValue
         playButton.setImage(BMImageResourcePath("Pod_Asset_BMPlayer_play"),  for: .normal)
@@ -620,18 +624,39 @@ open class BMPlayerControlView: UIView {
         
         topMaskView.snp.makeConstraints { (make) in
             make.top.left.right.equalTo(mainMaskView)
-            make.height.equalTo(65)
+        }
+        
+        topWrapperView.snp.makeConstraints { (make) in
+            make.height.equalTo(50)
+            
+            if #available(iOS 11.0, *) {
+                make.top.left.right.equalTo(topMaskView.safeAreaLayoutGuide)
+                make.bottom.equalToSuperview()
+            } else {
+                make.top.equalToSuperview().offset(15)
+                make.bottom.left.right.equalToSuperview()
+            }
         }
         
         bottomMaskView.snp.makeConstraints { (make) in
             make.bottom.left.right.equalTo(mainMaskView)
+        }
+        
+        bottomWrapperView.snp.makeConstraints { (make) in
             make.height.equalTo(50)
+            
+            if #available(iOS 11.0, *) {
+                make.bottom.left.right.equalTo(bottomMaskView.safeAreaLayoutGuide)
+                make.top.equalToSuperview()
+            } else {
+                make.edges.equalToSuperview()
+            }
         }
         
         // Top views
         backButton.snp.makeConstraints { (make) in
             make.width.height.equalTo(50)
-            make.left.bottom.equalTo(topMaskView)
+            make.left.bottom.equalToSuperview()
         }
         
         titleLabel.snp.makeConstraints { (make) in
@@ -640,7 +665,7 @@ open class BMPlayerControlView: UIView {
         }
         
         chooseDefinitionView.snp.makeConstraints { (make) in
-            make.right.equalTo(topMaskView.snp.right).offset(-20)
+            make.right.equalToSuperview().offset(-20)
             make.top.equalTo(titleLabel.snp.top).offset(-4)
             make.width.equalTo(60)
             make.height.equalTo(30)
@@ -650,7 +675,7 @@ open class BMPlayerControlView: UIView {
         playButton.snp.makeConstraints { (make) in
             make.width.equalTo(50)
             make.height.equalTo(50)
-            make.left.bottom.equalTo(bottomMaskView)
+            make.left.bottom.equalToSuperview()
         }
         
         currentTimeLabel.snp.makeConstraints { (make) in
@@ -681,12 +706,11 @@ open class BMPlayerControlView: UIView {
             make.height.equalTo(50)
             make.centerY.equalTo(currentTimeLabel)
             make.left.equalTo(totalTimeLabel.snp.right)
-            make.right.equalTo(bottomMaskView.snp.right)
+            make.right.equalToSuperview()
         }
         
         loadingIndicator.snp.makeConstraints { (make) in
-            make.centerX.equalTo(mainMaskView.snp.centerX).offset(0)
-            make.centerY.equalTo(mainMaskView.snp.centerY).offset(0)
+            make.center.equalTo(mainMaskView)
         }
         
         // View to show when slide to seek
@@ -709,8 +733,7 @@ open class BMPlayerControlView: UIView {
         }
         
         replayButton.snp.makeConstraints { (make) in
-            make.centerX.equalTo(mainMaskView.snp.centerX)
-            make.centerY.equalTo(mainMaskView.snp.centerY)
+            make.center.equalTo(mainMaskView)
             make.width.height.equalTo(50)
         }
         

--- a/Source/BMPlayerItem.swift
+++ b/Source/BMPlayerItem.swift
@@ -10,8 +10,8 @@ import Foundation
 import AVFoundation
 
 public class BMPlayerResource {
-    public let name  : String
-    public let cover : URL?
+    public let name: String
+    public let cover: URL?
     public var subtitle: BMSubtitles?
     public let definitions: [BMPlayerResourceDefinition]
     

--- a/Source/BMPlayerLayerView.swift
+++ b/Source/BMPlayerLayerView.swift
@@ -43,10 +43,10 @@ public enum BMPlayerAspectRatio : Int {
 }
 
 public protocol BMPlayerLayerViewDelegate : class {
-    func bmPlayer(player: BMPlayerLayerView ,playerStateDidChange state: BMPlayerState)
-    func bmPlayer(player: BMPlayerLayerView ,loadedTimeDidChange  loadedDuration: TimeInterval , totalDuration: TimeInterval)
-    func bmPlayer(player: BMPlayerLayerView ,playTimeDidChange    currentTime   : TimeInterval , totalTime: TimeInterval)
-    func bmPlayer(player: BMPlayerLayerView ,playerIsPlaying      playing: Bool)
+    func bmPlayer(player: BMPlayerLayerView, playerStateDidChange state: BMPlayerState)
+    func bmPlayer(player: BMPlayerLayerView, loadedTimeDidChange loadedDuration: TimeInterval, totalDuration: TimeInterval)
+    func bmPlayer(player: BMPlayerLayerView, playTimeDidChange currentTime: TimeInterval, totalTime: TimeInterval)
+    func bmPlayer(player: BMPlayerLayerView, playerIsPlaying playing: Bool)
 }
 
 open class BMPlayerLayerView: UIView {
@@ -87,14 +87,14 @@ open class BMPlayerLayerView: UIView {
         }
     }
     
-    var aspectRatio:BMPlayerAspectRatio = .default {
+    var aspectRatio: BMPlayerAspectRatio = .default {
         didSet {
             self.setNeedsLayout()
         }
     }
     
     /// 计时器
-    var timer       : Timer?
+    var timer: Timer?
     
     fileprivate var urlAsset: AVURLAsset?
     
@@ -120,7 +120,7 @@ open class BMPlayerLayerView: UIView {
     /// 是否播放本地文件
     fileprivate var isLocalVideo  = false
     /// slider上次的值
-    fileprivate var sliderLastValue:Float = 0
+    fileprivate var sliderLastValue: Float = 0
     /// 是否点了重播
     fileprivate var repeatToPlay  = false
     /// 播放完了
@@ -151,7 +151,6 @@ open class BMPlayerLayerView: UIView {
             isPlaying = true
         }
     }
-    
     
     open func pause() {
         player?.pause()
@@ -270,8 +269,6 @@ open class BMPlayerLayerView: UIView {
         playerItem = AVPlayerItem(asset: urlAsset!)
         player     = AVPlayer(playerItem: playerItem!)
         player!.addObserver(self, forKeyPath: "rate", options: NSKeyValueObservingOptions.new, context: nil)
-        
-        
         
         playerLayer?.removeFromSuperlayer()
         playerLayer = AVPlayerLayer(player: player)
@@ -410,6 +407,7 @@ open class BMPlayerLayerView: UIView {
     fileprivate func availableDuration() -> TimeInterval? {
         if let loadedTimeRanges = player?.currentItem?.loadedTimeRanges,
             let first = loadedTimeRanges.first {
+            
             let timeRange = first.timeRangeValue
             let startSeconds = CMTimeGetSeconds(timeRange.start)
             let durationSecound = CMTimeGetSeconds(timeRange.duration)

--- a/Source/BMPlayerProtocols.swift
+++ b/Source/BMPlayerProtocols.swift
@@ -23,8 +23,8 @@ extension BMPlayer {
         if seconds.isNaN {
             return "00:00"
         }
-        let Min = Int(seconds / 60)
-        let Sec = Int(seconds.truncatingRemainder(dividingBy: 60))
-        return String(format: "%02d:%02d", Min, Sec)
+        let min = Int(seconds / 60)
+        let sec = Int(seconds.truncatingRemainder(dividingBy: 60))
+        return String(format: "%02d:%02d", min, sec)
     }
 }

--- a/Source/BMSubtitles.swift
+++ b/Source/BMSubtitles.swift
@@ -99,7 +99,6 @@ public class BMSubtitles {
             var endString: NSString?
             scanner.scanUpToCharacters(from: .newlines, into: &endString)
             
-            
             var textString: NSString?
             scanner.scanUpTo("\r\n\r\n", into: &textString)
             

--- a/Source/BMTimeSlider.swift
+++ b/Source/BMTimeSlider.swift
@@ -10,9 +10,9 @@ import UIKit
 
 public class BMTimeSlider: UISlider {
     override open func trackRect(forBounds bounds: CGRect) -> CGRect {
-        let trackHeigt:CGFloat = 2
-        let position = CGPoint(x: 0 , y: 14)
-        let customBounds = CGRect(origin: position, size: CGSize(width: bounds.size.width, height: trackHeigt))
+        let trackHeight: CGFloat = 2
+        let position = CGPoint(x: 0, y: 14)
+        let customBounds = CGRect(origin: position, size: CGSize(width: bounds.size.width, height: trackHeight))
         super.trackRect(forBounds: customBounds)
         return customBounds
     }

--- a/Source/Default/BMPlayerManager.swift
+++ b/Source/Default/BMPlayerManager.swift
@@ -23,10 +23,10 @@ open class BMPlayerManager {
     open static let shared = BMPlayerManager()
     
     /// tint color
-    open var tintColor   = UIColor.white
+    open var tintColor = UIColor.white
     
     /// Loader
-    open var loaderType  = NVActivityIndicatorType.ballRotateChase
+    open var loaderType = NVActivityIndicatorType.ballRotateChase
     
     /// should auto play
     open var shouldAutoPlay = true
@@ -36,7 +36,7 @@ open class BMPlayerManager {
     open var animateDelayTimeInterval = TimeInterval(5)
     
     /// should show log
-    open var allowLog  = false
+    open var allowLog = false
     
     /// use gestures to set brightness, volume and play position
     open var enableBrightnessGestures = true


### PR DESCRIPTION
This PR also fix the following problem:

When the URL responses with a 403 error, `AVPlayer.state` will still be `readyToPlay`, so just checking the state of `AVPlayer` is not efficient. This PR checks states of both `AVPlayer` and `AVPlayerItem`. Either of them equals to `failed` will set the state of BMPlayerLayerView to `error`.

Example URL for test: 

`http://f.us.sinaimg.cn/003ouF2ylx07l6ffVojm010402006sYX0k010.mp4?label=mp4_hd&template=540x960.24&KID=unistore,video&Expires=1528455941&ssig=JOzoBLFjTv`