### PR TITLE
Seek after changing definition - fix

### DIFF
--- a/Source/BMPlayer.swift
+++ b/Source/BMPlayer.swift
@@ -469,6 +469,7 @@ extension BMPlayer: BMPlayerLayerViewDelegate {
                       self.pause()
                   }
                 })
+                shouldSeekTo = 0
             }
             
         case .bufferFinished:


### PR DESCRIPTION
When changing definition, the player was not able to seek to another position. 

Every seek was falling back to "shouldSeekTo != 0" and the player returned to the position where the definition was changed