### PR TITLE
Update BMPlayerLayerView.swift

### DIFF
--- a/Source/BMPlayerLayerView.swift
+++ b/Source/BMPlayerLayerView.swift
@@ -168,7 +168,7 @@ open class BMPlayerLayerView: UIView {
         super.layoutSubviews()
         switch self.aspectRatio {
         case .default:
-            self.playerLayer?.videoGravity = AVLayerVideoGravity.resizeAspect
+            self.playerLayer?.videoGravity = self.videoGravity
             self.playerLayer?.frame  = self.bounds
             break
         case .sixteen2NINE:


### PR DESCRIPTION
The .resizeAsspectFill gravity does not execute at the moment and you should handle it in default apsectRatio I think.