### PR TITLE
Updating deployment target and SnapKit

### DIFF
--- a/BMPlayer.podspec
+++ b/BMPlayer.podspec
@@ -40,7 +40,7 @@ s.subspec 'CacheSupport' do |cache|
     cache.frameworks   = 'UIKit', 'AVFoundation'
 
     cache.dependency 'BMPlayer/Core'
-    cache.dependency 'SnapKit', '~> 5.0.0'
+    cache.dependency 'SnapKit', '~> 5.7.1'
     cache.dependency 'NVActivityIndicatorView', '~> 4.7.0'
     cache.dependency 'VIMediaCache'
 end

--- a/BMPlayer.podspec
+++ b/BMPlayer.podspec
@@ -14,8 +14,8 @@ s.author           = { "Eliyar Eziz" => "eliyar917@gmail.com" }
 s.source           = { :git => "https://github.com/BrikerMan/BMPlayer.git", :tag => s.version.to_s }
 s.social_media_url = 'http://weibo.com/536445669'
 
-s.ios.deployment_target = '10.0'
-s.platform     = :ios, '10.0'
+s.ios.deployment_target = '12.0'
+s.platform     = :ios, '12.0'
 s.pod_target_xcconfig = { 'SWIFT_VERSION' => '5.0' }
 s.default_subspec = 'Full'
 

--- a/BMPlayer.podspec
+++ b/BMPlayer.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
 s.name             = "BMPlayer"
-s.version          = "1.3.2"
+s.version          = "1.3.3"
 s.summary          = "Video Player Using Swift, based on AVPlayer"
 s.swift_versions   = "5"
 s.description      = <<-DESC

--- a/BMPlayer.podspec
+++ b/BMPlayer.podspec
@@ -30,7 +30,7 @@ s.subspec 'Full' do |full|
     full.frameworks   = 'UIKit', 'AVFoundation'
 
     full.dependency 'BMPlayer/Core'
-    full.dependency 'SnapKit', '~> 5.0.0'
+    full.dependency 'SnapKit', '~> 5.7.1'
     full.dependency 'NVActivityIndicatorView', '~> 4.7.0'
 end
 
@@ -40,7 +40,7 @@ s.subspec 'CacheSupport' do |cache|
     cache.frameworks   = 'UIKit', 'AVFoundation'
 
     cache.dependency 'BMPlayer/Core'
-    cache.dependency 'SnapKit', '~> 5.7.1'
+    cache.dependency 'SnapKit', '~> 5.0.0'
     cache.dependency 'NVActivityIndicatorView', '~> 4.7.0'
     cache.dependency 'VIMediaCache'
 end


### PR DESCRIPTION
- Apple requires to include a privacy manifest in some libraries https://developer.apple.com/support/third-party-SDK-requirements/. To comply I have updated SnapKit to version 5.7.1
- Updated deployment target to 12.0 to match the deployment target for SnapKit version 5.7.1